### PR TITLE
Fixes #2: constant overflows uint on 32 bit platforms

### DIFF
--- a/client_disk.go
+++ b/client_disk.go
@@ -71,7 +71,7 @@ type UploadImageResult interface {
 type Disk interface {
 	ID() string
 	Alias() string
-	ProvisionedSize() uint
+	ProvisionedSize() uint64
 	Format() ImageFormat
 	StorageDomainID() string
 }
@@ -135,7 +135,7 @@ func convertSDKDisk(sdkDisk *ovirtsdk4.Disk) (Disk, error) {
 	return &disk{
 		id:              id,
 		alias:           alias,
-		provisionedSize: uint(provisionedSize),
+		provisionedSize: uint64(provisionedSize),
 		format:          ImageFormat(format),
 		storageDomainID: storageDomainID,
 	}, nil
@@ -144,7 +144,7 @@ func convertSDKDisk(sdkDisk *ovirtsdk4.Disk) (Disk, error) {
 type disk struct {
 	id              string
 	alias           string
-	provisionedSize uint
+	provisionedSize uint64
 	format          ImageFormat
 	storageDomainID string
 }
@@ -157,7 +157,7 @@ func (d disk) Alias() string {
 	return d.alias
 }
 
-func (d disk) ProvisionedSize() uint {
+func (d disk) ProvisionedSize() uint64 {
 	return d.provisionedSize
 }
 

--- a/client_storagedomain.go
+++ b/client_storagedomain.go
@@ -17,7 +17,7 @@ type StorageDomain interface {
 	ID() string
 	Name() string
 	// Available returns the number of available bytes on the storage domain
-	Available() uint
+	Available() uint64
 	// Status returns the status of the storage domain. This status may be unknown if the storage domain is external.
 	// Check ExternalStatus as well.
 	Status() StorageDomainStatus
@@ -80,7 +80,7 @@ func convertSDKStorageDomain(sdkStorageDomain *ovirtsdk4.StorageDomain) (Storage
 	return &storageDomain{
 		id:             id,
 		name:           name,
-		available:      uint(available),
+		available:      uint64(available),
 		status:         StorageDomainStatus(status),
 		externalStatus: StorageDomainExternalStatus(externalStatus),
 	}, nil
@@ -89,7 +89,7 @@ func convertSDKStorageDomain(sdkStorageDomain *ovirtsdk4.StorageDomain) (Storage
 type storageDomain struct {
 	id             string
 	name           string
-	available      uint
+	available      uint64
 	status         StorageDomainStatus
 	externalStatus StorageDomainExternalStatus
 }
@@ -102,7 +102,7 @@ func (s storageDomain) Name() string {
 	return s.name
 }
 
-func (s storageDomain) Available() uint {
+func (s storageDomain) Available() uint64 {
 	return s.available
 }
 

--- a/mock_disk_uploadimage.go
+++ b/mock_disk_uploadimage.go
@@ -37,7 +37,7 @@ func (m *mockClient) StartImageUpload(
 		disk: disk{
 			id:              "",
 			alias:           alias,
-			provisionedSize: uint(size),
+			provisionedSize: size,
 			format:          format,
 			storageDomainID: storageDomainID,
 		},


### PR DESCRIPTION
## Please describe the change you are making

This change fixes #2 where an uint overflows on 32 bit platforms.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
