### PR TITLE
No retry on disk status "illegal"

### DIFF
--- a/client_disk_helper_imagetransfer.go
+++ b/client_disk_helper_imagetransfer.go
@@ -227,10 +227,14 @@ func (i *imageTransferImpl) checkDiskOk() (Disk, error) {
 	if err != nil {
 		return nil, err
 	}
-	if disk.Status() != DiskStatusOK {
-		return nil, newError(EPending, "disk status is %s, not ok", disk.Status())
+	switch disk.Status() {
+	case DiskStatusOK:
+		return disk, nil
+	case DiskStatusLocked:
+		return nil, newError(EPending, "disk status is %s, not %s", disk.Status(), DiskStatusOK)
+	default:
+		return nil, newError(EUnexpectedDiskStatus, "disk status is %s, not %s", disk.Status(), DiskStatusOK)
 	}
-	return disk, nil
 }
 
 // buildImageTransferRequest creates an SDK image transfer request and the associated service.

--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,9 @@ const ETemporaryHTTPError ErrorCode = "temporary_http_error"
 // EPending signals that the client library is still waiting for an action to be completed.
 const EPending ErrorCode = "pending"
 
+// EUnexpectedDiskStatus indicates that a disk was in a status that was not expected in this state.
+const EUnexpectedDiskStatus ErrorCode = "unexpected_disk_status"
+
 // ETimeout signals that the client library has timed out waiting for an action to be completed.
 const ETimeout ErrorCode = "timeout"
 
@@ -93,6 +96,8 @@ func (e ErrorCode) CanAutoRetry() bool {
 	case EFieldMissing:
 		return false
 	case EPermanentHTTPError:
+		return false
+	case EUnexpectedDiskStatus:
 		return false
 	default:
 		return true


### PR DESCRIPTION
## Please describe the change you are making

This changes the image transfer to abort if the disk status is "illegal", which is a non-recoverable state.
