### PR TITLE
Split data objects

### DIFF
--- a/client_datacenter.go
+++ b/client_datacenter.go
@@ -18,11 +18,16 @@ type DatacenterClient interface {
 	ListDatacenterClusters(id string, retries ...RetryStrategy) ([]Cluster, error)
 }
 
+// DatacenterData is the core of a Datacenter when client functions are not required.
+type DatacenterData interface {
+	ID() string
+	Name() string
+}
+
 // Datacenter is a logical entity that defines the set of resources used in a specific environment.
 // See https://www.ovirt.org/documentation/administration_guide/#chap-Data_Centers for details.
 type Datacenter interface {
-	ID() string
-	Name() string
+	DatacenterData
 
 	// Clusters lists the clusters for this datacenter. This is a network call and may be slow.
 	Clusters(retries ...RetryStrategy) ([]Cluster, error)

--- a/client_disk.go
+++ b/client_disk.go
@@ -324,8 +324,9 @@ type UploadImageResult interface {
 	Disk() Disk
 }
 
-// Disk is a disk in oVirt.
-type Disk interface {
+// DiskData is the core of a Disk, only exposing data functions, but not the client functions.
+// This can be used for cases where not a full Disk is required, but only the data functionality.
+type DiskData interface {
 	// ID is the unique ID for this disk.
 	ID() string
 	// Alias is the name for this disk set by the user.
@@ -341,6 +342,11 @@ type Disk interface {
 	StorageDomainID() string
 	// Status returns the status the disk is in.
 	Status() DiskStatus
+}
+
+// Disk is a disk in oVirt.
+type Disk interface {
+	DiskData
 
 	// StartDownload starts the download of the image file the current disk.
 	// The caller can then wait for the initialization using the Initialized() call:

--- a/client_host.go
+++ b/client_host.go
@@ -12,18 +12,23 @@ type HostClient interface {
 	GetHost(id string, retries ...RetryStrategy) (Host, error)
 }
 
-// Host is the representation of a host returned from the oVirt Engine API. Hosts, also known as hypervisors, are the
-// physical servers on which virtual machines run. Full virtualization is provided by using a loadable Linux kernel
-// module called Kernel-based Virtual Machine (KVM).
-//
-// See https://www.ovirt.org/documentation/administration_guide/#chap-Hosts for details.
-type Host interface {
+// HostData is the core of Host, providing only data access functions.
+type HostData interface {
 	// ID returns the identifier of the host in question.
 	ID() string
 	// ClusterID returns the ID of the cluster this host belongs to.
 	ClusterID() string
 	// Status returns the status of this host.
 	Status() HostStatus
+}
+
+// Host is the representation of a host returned from the oVirt Engine API. Hosts, also known as hypervisors, are the
+// physical servers on which virtual machines run. Full virtualization is provided by using a loadable Linux kernel
+// module called Kernel-based Virtual Machine (KVM).
+//
+// See https://www.ovirt.org/documentation/administration_guide/#chap-Hosts for details.
+type Host interface {
+	HostData
 }
 
 // HostStatus represents the complex states an oVirt host can be in.

--- a/client_network.go
+++ b/client_network.go
@@ -16,15 +16,20 @@ type NetworkClient interface {
 	ListNetworks(retries ...RetryStrategy) ([]Network, error)
 }
 
-// Network is the interface defining the fields for networks.
-type Network interface {
+// NetworkData is the core of Network, providing only the data access functions, but not the client
+// functions.
+type NetworkData interface {
 	// ID returns the auto-generated identifier for this network.
 	ID() string
 	// Name returns the user-give nname for this network.
 	Name() string
-
 	// DatacenterID is the identifier of the datacenter object.
 	DatacenterID() string
+}
+
+// Network is the interface defining the fields for networks.
+type Network interface {
+	NetworkData
 
 	// Datacenter fetches the datacenter associated with this network. This is a network call and may be slow.
 	Datacenter(retries ...RetryStrategy) (Datacenter, error)

--- a/client_nic.go
+++ b/client_nic.go
@@ -16,8 +16,8 @@ type NICClient interface {
 	RemoveNIC(vmid string, id string, retries ...RetryStrategy) error
 }
 
-// NIC represents a network interface.
-type NIC interface {
+// NICData is the core of NIC which only provides data-access functions.
+type NICData interface {
 	// ID is the identifier for this network interface.
 	ID() string
 	// Name is the user-given name of the network interface.
@@ -26,6 +26,11 @@ type NIC interface {
 	VMID() string
 	// VNICProfileID returns the ID of the VNIC profile in use by the NIC.
 	VNICProfileID() string
+}
+
+// NIC represents a network interface.
+type NIC interface {
+	NICData
 
 	// GetVM fetches an up to date copy of the virtual machine this NIC is attached to. This involves an API call and
 	// may be slow.

--- a/client_storagedomain.go
+++ b/client_storagedomain.go
@@ -14,8 +14,8 @@ type StorageDomainClient interface {
 	GetStorageDomain(id string, retries ...RetryStrategy) (StorageDomain, error)
 }
 
-// StorageDomain represents a storage domain returned from the oVirt Engine API.
-type StorageDomain interface {
+// StorageDomainData is the core of StorageDomain, providing only data access functions.
+type StorageDomainData interface {
 	// ID is the unique identified for the storage system connected to oVirt.
 	ID() string
 	// Name is the user-given name for the storage domain.
@@ -27,6 +27,11 @@ type StorageDomain interface {
 	Status() StorageDomainStatus
 	// ExternalStatus returns the external status of a storage domain.
 	ExternalStatus() StorageDomainExternalStatus
+}
+
+// StorageDomain represents a storage domain returned from the oVirt Engine API.
+type StorageDomain interface {
+	StorageDomainData
 }
 
 // StorageDomainStatus represents the status a domain can be in. Either this status field, or the

--- a/client_vm.go
+++ b/client_vm.go
@@ -25,8 +25,8 @@ type VMClient interface {
 	RemoveVM(id string, retries ...RetryStrategy) error
 }
 
-// VM is the implementation of the virtual machine in oVirt.
-type VM interface {
+// VMData is the core of VM providing only data access functions.
+type VMData interface {
 	// ID returns the unique identifier (UUID) of the current virtual machine.
 	ID() string
 	// Name is the user-defined name of the virtual machine.
@@ -39,6 +39,11 @@ type VM interface {
 	TemplateID() string
 	// Status returns the current status of the VM.
 	Status() VMStatus
+}
+
+// VM is the implementation of the virtual machine in oVirt.
+type VM interface {
+	VMData
 
 	// Remove removes the current VM. This involves an API call and may be slow.
 	Remove(retries ...RetryStrategy) error

--- a/client_vnicprofile.go
+++ b/client_vnicprofile.go
@@ -14,15 +14,20 @@ type VNICProfileClient interface {
 	ListVNICProfiles(retries ...RetryStrategy) ([]VNICProfile, error)
 }
 
-// VNICProfile is a collection of settings that can be applied to individual virtual network interface cards in the
-// Engine.
-type VNICProfile interface {
+// VNICProfileData is the core of VNICProfile, providing only data access functions.
+type VNICProfileData interface {
 	// ID returns the identifier of the VNICProfile.
 	ID() string
 	// Name returns the human-readable name of the VNIC profile.
 	Name() string
 	// NetworkID returns the network ID the VNICProfile is attached to.
 	NetworkID() string
+}
+
+// VNICProfile is a collection of settings that can be applied to individual virtual network interface cards in the
+// Engine.
+type VNICProfile interface {
+	VNICProfileData
 
 	// Network fetches the network object from the oVirt engine. This is an API call and may be slow.
 	Network(retries ...RetryStrategy) (Network, error)


### PR DESCRIPTION
This change splits the data objects (e.g. VM) into two parts to satisfy the Interface Segregation Principle (e.g. VM and VMData). This will allow implementers (e.g. the Terraform provider) to only use the smaller interface for tests and other use cases.