### PR TITLE
Ignore sub-directories in addCertsFromDir.

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -171,7 +171,7 @@ func (s *standardTLSProvider) addCertsFromDir(certPool *x509.CertPool) error {
 		}
 		for _, info := range files {
 			if info.IsDir() {
-				return nil
+				continue
 			}
 			if len(dir.patterns) > 0 {
 				matches := false


### PR DESCRIPTION
## Please describe the change you are making
When addCertsFromDir encounters a sub-directory, ignore it instead of immediately returning. I tried using CACertsFromDir in CDI, and it was failing because there were some irrelevant directories listed before ca.pem. This seems like the simplest way to fix it, unless there is a particular reason for the current behavior?

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes.

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes.