### PR TITLE
Fix minor documentation issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This library is built to wrap [go-ovirt](https://github.com/ovirt/go-ovirt), whi
 
 ## Tooling
 
-The main tool to develop this library apart from Go itself is [golangci-lint](https://golanci-lint.run). You can use this tool to sanity-check your code before submitting a PR.
+The main tool to develop this library apart from Go itself is [golangci-lint](https://golangci-lint.run). You can use this tool to sanity-check your code before submitting a PR.
 
 ```
 golangci-lint run

--- a/README.md
+++ b/README.md
@@ -30,23 +30,23 @@ func main() {
 
     // Create an ovirtclient.TLSProvider implementation. This allows for simple
     // TLS configuration.
-	tls := ovirtclient.TLS()
+    tls := ovirtclient.TLS()
 
-	// Add certificates from an in-memory byte slice. Certificates must be in PEM format.
-	tls.CACertsFromMemory(caCerts)
-	
-	// Add certificates from a single file. Certificates must be in PEM format.
-	tls.CACertsFromFile("/path/to/file.pem")
+    // Add certificates from an in-memory byte slice. Certificates must be in PEM format.
+    tls.CACertsFromMemory(caCerts)
+    
+    // Add certificates from a single file. Certificates must be in PEM format.
+    tls.CACertsFromFile("/path/to/file.pem")
 
-	// Add certificates from a directory. Optionally, regular expressions can be passed that must match the file
-	// names.
-	tls.CACertsFromDir("/path/to/certs", regexp.MustCompile(`\.pem`)) 
+    // Add certificates from a directory. Optionally, regular expressions can be passed that must match the file
+    // names.
+    tls.CACertsFromDir("/path/to/certs", regexp.MustCompile(`\.pem`)) 
 
-	// Add system certificates
-	tls.CACertsFromSystem()
+    // Add system certificates
+    tls.CACertsFromSystem()
 
-	// Disable certificate verification. This is a bad idea, please don't do this.
-	tls.Insecure()
+    // Disable certificate verification. This is a bad idea, please don't do this.
+    tls.Insecure()
 
     // Create a new goVirt instance:
     client, err := ovirtclient.New(
@@ -84,7 +84,7 @@ Either it sets up test fixtures in the mock client, or it sets up a live connect
 domain, cluster, etc. for testing purposes.
 
 The easiest way to set up the test helper is using environment variables. To do that, you can use the
-ovirtclient.NewTestHelperFromEnv() function:
+`ovirtclient.NewTestHelperFromEnv()` function:
 
 ```go
 helper := ovirtclient.NewTestHelperFromEnv(ovirtclientlog.NewNOOPLogger())
@@ -93,7 +93,7 @@ helper := ovirtclient.NewTestHelperFromEnv(ovirtclientlog.NewNOOPLogger())
 This function will inspect environment variables to determine if a connection to a live oVirt engine can be estabilshed.
 The following environment variables are supported:
 
-- `OVIRT_URL`: URL of the oVirt engine.
+- `OVIRT_URL`: URL of the oVirt engine API.
 - `OVIRT_USERNAME`: The username for the oVirt engine.
 - `OVIRT_PASSWORD`: The password for the oVirt engine
 - `OVIRT_CAFILE`: A file containing the CA certificate in PEM format.
@@ -124,7 +124,7 @@ func TestSomething(t *testing.T) {
 
     // Create the test helper
     helper, err := ovirtclient.NewTestHelper(
-        "https://localhost/ovirt-engine/",
+        "https://localhost/ovirt-engine/api",
         "admin@internal",
         "super-secret",
         ovirtclient.TLS().CACertsFromSystem(),

--- a/doc.go
+++ b/doc.go
@@ -17,7 +17,7 @@ There are several ways to create a client instance. The most basic way is to use
     // Create the client
     client, err := ovirtclient.New(
         // URL
-        "https://localhost/ovirt-engine/",
+        "https://localhost/ovirt-engine/api",
         // Username
         "admin@internal",
         // Password
@@ -62,7 +62,7 @@ established. The following environment variables are supported:
 
   OVIRT_URL
 
-URL of the oVirt engine.
+URL of the oVirt engine API.
 
   OVIRT_USERNAME
 
@@ -119,7 +119,7 @@ You can also create the test helper manually:
 
         // Create the test helper
         helper, err := ovirtclient.NewTestHelper(
-            "https://localhost/ovirt-engine/",
+            "https://localhost/ovirt-engine/api",
             "admin@internal",
             "super-secret",
             ovirtclient.TLS().CACertsFromSystem(),
@@ -174,7 +174,7 @@ Modern-day oVirt engines run secured with TLS. This means that the client needs 
 server is presenting. This is controlled by the tls parameter of the New() function. You can implement your own source
 by implementing the TLSProvider interface, but the package also includes a ready-to-use provider.
 
-Create the provider using the TLS() functionL
+Create the provider using the TLS() function:
 
     tls := ovirtclient.TLS()
 


### PR DESCRIPTION
Fix couple of minor issues in the documentation and README:
* add `api` suffix into `OVIRT_URL` parameter and mention it in the doc
* replace tabs with space in code example to have correct formatting
* fix typos