### PR TITLE
Tests and docs for loading TLS from a cert pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,59 +20,68 @@ You can then create a client instance like this:
 package main
 
 import (
-    "github.com/ovirt/go-client-log"
-    "github.com/ovirt/go-ovirt-client"
+	"crypto/x509"
+
+	"github.com/ovirt/go-client-log"
+	"github.com/ovirt/go-ovirt-client"
 )
 
 func main() {
-    // Create a logger that logs to the standard Go log here:
-    logger := ovirtclientlog.NewGoLogLogger(nil)
+	// Create a logger that logs to the standard Go log here:
+	logger := ovirtclientlog.NewGoLogLogger(nil)
 
-    // Create an ovirtclient.TLSProvider implementation. This allows for simple
-    // TLS configuration.
-    tls := ovirtclient.TLS()
+	// Create an ovirtclient.TLSProvider implementation. This allows for simple
+	// TLS configuration.
+	tls := ovirtclient.TLS()
 
-    // Add certificates from an in-memory byte slice. Certificates must be in PEM format.
-    tls.CACertsFromMemory(caCerts)
-    
-    // Add certificates from a single file. Certificates must be in PEM format.
-    tls.CACertsFromFile("/path/to/file.pem")
+	// Add certificates from an in-memory byte slice. Certificates must be in PEM format.
+	tls.CACertsFromMemory(caCerts)
 
-    // Add certificates from a directory. Optionally, regular expressions can be passed that must match the file
-    // names.
-    tls.CACertsFromDir("/path/to/certs", regexp.MustCompile(`\.pem`)) 
+	// Add certificates from a single file. Certificates must be in PEM format.
+	tls.CACertsFromFile("/path/to/file.pem")
 
-    // Add system certificates
-    tls.CACertsFromSystem()
+	// Add certificates from a directory. Optionally, regular expressions can be passed that must match the file
+	// names.
+	tls.CACertsFromDir(
+		"/path/to/certs",
+		regexp.MustCompile(`\.pem`),
+	)
 
-    // Disable certificate verification. This is a bad idea, please don't do this.
-    tls.Insecure()
+	// Add system certificates. This doesn't work on Windows.
+	tls.CACertsFromSystem()
 
-    // Create a new goVirt instance:
-    client, err := ovirtclient.New(
-        // URL to your oVirt engine API here:
-        "https://your-ovirt-engine/ovirt-engine/api/",
-        // Username here:
-        "admin@internal",
-        // Password here:
-        "password-here",
-        // Pass the TLS provider here:
-        tls,
-        // Pass the logger here:
-        logger,
-        // Pass in extra settings here. Must implement the ovirtclient.ExtraSettings interface.
-        nil,
-    )
-    if err != nil {
-        // Handle error, here in a really crude way:
-        panic(err)
-    }
-    // Use client. Please use the code completion in your IDE to
-    // discover the functions. Each is well documented.
-    upload, err := client.StartUploadToNewDisk(
-        //...
-    )
-    //....
+	// Add a custom cert pool as a source of certificates. This option is
+	// incompatible with CACertsFromSystem.
+	tls.CACertsFromCertPool(x509.NewCertPool())
+
+	// Disable certificate verification. This is a bad idea, please don't do this.
+	tls.Insecure()
+
+	// Create a new goVirt instance:
+	client, err := ovirtclient.New(
+		// URL to your oVirt engine API here:
+		"https://your-ovirt-engine/ovirt-engine/api/",
+		// Username here:
+		"admin@internal",
+		// Password here:
+		"password-here",
+		// Pass the TLS provider here:
+		tls,
+		// Pass the logger here:
+		logger,
+		// Pass in extra settings here. Must implement the ovirtclient.ExtraSettings interface.
+		nil,
+	)
+	if err != nil {
+		// Handle error, here in a really crude way:
+		panic(err)
+	}
+	// Use client. Please use the code completion in your IDE to
+	// discover the functions. Each is well documented.
+	upload, err := client.StartUploadToNewDisk(
+		//...
+	)
+	//....
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
 
 	// Add a custom cert pool as a source of certificates. This option is
 	// incompatible with CACertsFromSystem.
-	tls.CACertsFromCertPool(x509.NewCertPool())
+	// tls.CACertsFromCertPool(x509.NewCertPool())
 
 	// Disable certificate verification. This is a bad idea, please don't do this.
 	tls.Insecure()

--- a/doc.go
+++ b/doc.go
@@ -188,6 +188,9 @@ Now you need to add your oVirt engine certificate to your system trust root.
 If you don't want to, or can't add the certificate to the system trust root, you can also directly provide it
 to the client.
 
+    // Add certificates from a certificate pool you have previously initialized.
+    tls.CACertsFromCertPool(certpool)
+
     // Add certificates from an in-memory byte slice. Certificates must be in PEM format.
     tls.CACertsFromMemory([]byte("-----BEGIN CERTIFICATE-----\n..."))
 

--- a/tls.go
+++ b/tls.go
@@ -41,6 +41,10 @@ type BuildableTLSProvider interface {
 	// CACertsFromSystem adds the system certificate store. This may fail because the certificate store is not available
 	// or not supported on the platform.
 	CACertsFromSystem() BuildableTLSProvider
+
+	// CACertsFromCertPool sets a certificate pool to use as a source for certificates. This is incompatible with  the
+	// CACertsFromSystem call as both create a certificate pool.
+	CACertsFromCertPool(*x509.CertPool) BuildableTLSProvider
 }
 
 // TLS creates a BuildableTLSProvider that can be used to easily add trusted CA certificates and generally follows best
@@ -48,15 +52,6 @@ type BuildableTLSProvider interface {
 func TLS() BuildableTLSProvider {
 	return &standardTLSProvider{
 		lock: &sync.Mutex{},
-	}
-}
-
-// TLSWithCertPool creates a BuildableTLSProvider from a pre-configured CertPool.
-func TLSWithCertPool(certPool *x509.CertPool) BuildableTLSProvider {
-	return &standardTLSProvider{
-		lock:       &sync.Mutex{},
-		certPool:   certPool,
-		configured: true,
 	}
 }
 
@@ -81,6 +76,14 @@ func (s *standardTLSProvider) Insecure() TLSProvider {
 	defer s.lock.Unlock()
 	s.configured = true
 	s.insecure = true
+	return s
+}
+
+func (s *standardTLSProvider) CACertsFromCertPool(certPool *x509.CertPool) BuildableTLSProvider {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.configured = true
+	s.certPool = certPool
 	return s
 }
 
@@ -251,6 +254,12 @@ func (s *standardTLSProvider) addCertsFromMemory(certPool *x509.CertPool) error 
 }
 
 func (s *standardTLSProvider) createCertPool() (*x509.CertPool, error) {
+	if s.system && s.certPool != nil {
+		return nil, newError(ETLSError, "both system and cert pool are specified, these options are incompatible")
+	}
+	if s.certPool != nil {
+		return s.certPool, nil
+	}
 	if !s.system {
 		return x509.NewCertPool(), nil
 	}

--- a/tls.go
+++ b/tls.go
@@ -43,7 +43,7 @@ type BuildableTLSProvider interface {
 	CACertsFromSystem() BuildableTLSProvider
 
 	// CACertsFromCertPool sets a certificate pool to use as a source for certificates. This is incompatible with  the
-	// CACertsFromSystem call as both create a certificate pool.
+	// CACertsFromSystem call as both create a certificate pool. This function must not be called twice.
 	CACertsFromCertPool(*x509.CertPool) BuildableTLSProvider
 }
 
@@ -82,6 +82,9 @@ func (s *standardTLSProvider) Insecure() TLSProvider {
 func (s *standardTLSProvider) CACertsFromCertPool(certPool *x509.CertPool) BuildableTLSProvider {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.certPool != nil {
+		panic(newError(EConflict, "the CACertsFromCertPool function has been called twice"))
+	}
 	s.configured = true
 	s.certPool = certPool
 	return s

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,6 +1,7 @@
 package ovirtclient_test
 
 import (
+	"crypto/x509"
 	"fmt"
 	"regexp"
 
@@ -21,7 +22,7 @@ func ExampleTLS() {
 	// names.
 	tls.CACertsFromDir("/path/to/certs", regexp.MustCompile(`\.pem`))
 
-	// Add system certificates
+	// Add system certificates. This does not work on Windows.
 	tls.CACertsFromSystem()
 
 	// Disable certificate verification. This is a bad idea.
@@ -38,4 +39,25 @@ func ExampleTLS() {
 		fmt.Printf("Certificate verification is enabled.")
 	}
 	// Output: Certificate verification is disabled.
+}
+
+// This example shows how to set up TLS verification from an existing certificate pool.
+func ExampleBuildableTLSProvider_CACertsFromCertPool() {
+	tls := ovirtclient.TLS()
+
+	// Add custom certificate pool as a source of certificates.
+	certPool := x509.NewCertPool()
+	tls.CACertsFromCertPool(certPool)
+
+	// This will typically be called by the ovirtclient.New() function to create a TLS certificate.
+	tlsConfig, err := tls.CreateTLSConfig()
+	if err != nil {
+		panic(fmt.Errorf("failed to create TLS config (%w)", err))
+	}
+	if tlsConfig.InsecureSkipVerify {
+		fmt.Printf("Certificate verification is disabled.")
+	} else {
+		fmt.Printf("Certificate verification is enabled.")
+	}
+	// Output: Certificate verification is enabled.
 }


### PR DESCRIPTION
## Please describe the change you are making

This change adds functionality to #60 to allow the certificate pool to be actually used. It also moves the TLS initialization to a builder function to make it more flexible.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
