### PR TITLE
Fixing gosec linting errors

### DIFF
--- a/client_disk_downloadimage_test.go
+++ b/client_disk_downloadimage_test.go
@@ -13,7 +13,9 @@ import (
 func TestImageDownload(t *testing.T) {
 	testImageData := getTestImageData(t)
 	fh, stat := getTestImageFile(t)
-	defer func() {
+	// We are ignoring G307/CWE-703 here because it's a short-lived test function and a file
+	// left open won't cause any problems.
+	defer func() { //nolint:gosec
 		_ = fh.Close()
 	}()
 

--- a/client_disk_uploadimage_test.go
+++ b/client_disk_uploadimage_test.go
@@ -9,7 +9,9 @@ import (
 
 func TestImageUploadDiskCreated(t *testing.T) {
 	fh, stat := getTestImageFile(t)
-	defer func() {
+	// We are ignoring G307/CWE-703 here because it's a short-lived test function and a file
+	// left open won't cause any problems.
+	defer func() { //nolint:gosec
 		_ = fh.Close()
 	}()
 
@@ -39,7 +41,9 @@ func TestImageUploadDiskCreated(t *testing.T) {
 
 func TestImageUploadToExistingDisk(t *testing.T) {
 	fh, stat := getTestImageFile(t)
-	defer func() {
+	// We are ignoring G307/CWE-703 here because it's a short-lived test function and a file
+	// left open won't cause any problems.
+	defer func() { //nolint:gosec
 		_ = fh.Close()
 	}()
 

--- a/example_vm_uploadimage_test.go
+++ b/example_vm_uploadimage_test.go
@@ -18,8 +18,11 @@ func ExampleDiskClient_uploadImage() {
 	if err != nil {
 		panic(fmt.Errorf("failed to open image file (%w)", err))
 	}
-	defer func() {
-		_ = fh.Close()
+	// Skip gosec linting because we are throwing a panic anyway.
+	defer func() { //nolint:gosec
+		if err = fh.Close(); err != nil {
+			panic(err)
+		}
 	}()
 
 	// Get the file size
@@ -55,8 +58,11 @@ func ExampleDiskClient_uploadImageWithCancel() {
 	if err != nil {
 		panic(fmt.Errorf("failed to open image file (%w)", err))
 	}
-	defer func() {
-		_ = fh.Close()
+	// Skip gosec linting because we are throwing a panic anyway.
+	defer func() { //nolint:gosec
+		if err = fh.Close(); err != nil {
+			panic(err)
+		}
 	}()
 
 	// Get the file size

--- a/scripts/rest.go
+++ b/scripts/rest.go
@@ -195,7 +195,9 @@ func handleTemplateFile(templateFileName string, id string, targetDir string, re
 	if err != nil {
 		return fmt.Errorf("failed to open %s (%w)", templateFileName, err)
 	}
-	defer func() {
+	// We are skipping gosec linting for G307/CWE-703 because this code is only used for
+	// generating code and the process will terminate in short order anyway.
+	defer func() { //nolint:gosec
 		_ = fh.Close()
 	}()
 	data, err := ioutil.ReadAll(fh)
@@ -222,14 +224,14 @@ func handleTemplateFile(templateFileName string, id string, targetDir string, re
 }
 
 func runGoFmt(t string) error {
-	cmd := exec.Command("gofmt", "-w", t) // nolint:gosec
+	cmd := exec.Command("gofmt", "-w", t)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
 func runGoLint(t string) error {
-	cmd := exec.Command("golangci-lint", "run", t) // nolint:gosec
+	cmd := exec.Command("golangci-lint", "run", t)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -253,7 +255,9 @@ func renderTemplate(tplText string, file string, restItem restItem) error {
 	if err != nil {
 		return fmt.Errorf("failed to open %s (%w)", file, err)
 	}
-	defer func() {
+	// We are skipping gosec linting for G307/CWE-703 because this code is only used for
+	// generating code and the process will terminate in short order anyway.
+	defer func() { //nolint:gosec
 		if err := fh.Close(); err != nil {
 			panic(fmt.Errorf("failed to close %s (%w)", file, err))
 		}


### PR DESCRIPTION
## Please describe the change you are making

This change fixes linting errors in #64 by properly annotating gosec failures.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
