### PR TITLE
Removed annoying gofumpt requirement

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,8 @@ linters:
     - importas
     # Make package imports always deterministic.
     - gci
+    # Make code properly formatted.
+    - gofmt
     # Prevent faulty error checks.
     - nilerr
     # Prevent direct error checks that won't work with wrapped errors.
@@ -75,15 +77,6 @@ linters:
     - durationcheck
     # Enforce tests being in the _test package.
     - testpackage
-
-    # endregion
-
-
-    # region Code formatting
-
-    # Enforce proper white-space handling.
-    - gofumpt
-    - whitespace
 
     # endregion
 linters-settings:


### PR DESCRIPTION
## Please describe the change you are making

I propose removing the requirement to run `gofumpt` on the code. Instead, just simply `gofmt` will do to make it more contribution-friendly.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
