### PR TITLE
Removing StorageDomain() and adding StorageDomains() on Disk objects

### DIFF
--- a/mock_disk.go
+++ b/mock_disk.go
@@ -31,15 +31,15 @@ func (d *diskWithData) Unlock() {
 func (d *diskWithData) WithAlias(alias *string) *diskWithData {
 	return &diskWithData{
 		disk{
-			client:          d.client,
-			id:              d.id,
-			alias:           *alias,
-			provisionedSize: d.provisionedSize,
-			format:          d.format,
-			storageDomainID: d.storageDomainID,
-			status:          d.status,
-			totalSize:       d.totalSize,
-			sparse:          d.sparse,
+			client:           d.client,
+			id:               d.id,
+			alias:            *alias,
+			provisionedSize:  d.provisionedSize,
+			format:           d.format,
+			storageDomainIDs: d.storageDomainIDs,
+			status:           d.status,
+			totalSize:        d.totalSize,
+			sparse:           d.sparse,
 		},
 		d.lock,
 		d.data,
@@ -48,19 +48,22 @@ func (d *diskWithData) WithAlias(alias *string) *diskWithData {
 
 func (d *diskWithData) withProvisionedSize(ps uint64) (*diskWithData, error) {
 	if d.provisionedSize > ps {
-		return nil, newError(EBadArgument, "Cannot edit Virtual Disk. New disk size must be larger than the current disk size")
+		return nil, newError(
+			EBadArgument,
+			"Cannot edit Virtual Disk. New disk size must be larger than the current disk size",
+		)
 	}
 	return &diskWithData{
 		disk{
-			client:          d.client,
-			id:              d.id,
-			alias:           d.alias,
-			provisionedSize: ps,
-			format:          d.format,
-			storageDomainID: d.storageDomainID,
-			status:          d.status,
-			totalSize:       ps,
-			sparse:          d.sparse,
+			client:           d.client,
+			id:               d.id,
+			alias:            d.alias,
+			provisionedSize:  ps,
+			format:           d.format,
+			storageDomainIDs: d.storageDomainIDs,
+			status:           d.status,
+			totalSize:        ps,
+			sparse:           d.sparse,
 		},
 		d.lock,
 		d.data,

--- a/mock_disk_create.go
+++ b/mock_disk_create.go
@@ -41,13 +41,13 @@ func (m *mockClient) createDisk(
 
 	disk := &diskWithData{
 		disk: disk{
-			client:          m,
-			id:              m.GenerateUUID(),
-			format:          format,
-			provisionedSize: size,
-			totalSize:       size,
-			storageDomainID: storageDomainID,
-			status:          DiskStatusLocked,
+			client:           m,
+			id:               m.GenerateUUID(),
+			format:           format,
+			provisionedSize:  size,
+			totalSize:        size,
+			storageDomainIDs: []string{storageDomainID},
+			status:           DiskStatusLocked,
 		},
 		lock: &sync.Mutex{},
 		data: nil,


### PR DESCRIPTION
## Please describe the change you are making

This change removes the `StorageDomain()` function and adds the `StorageDomains()` function to more accurately reflect how oVirt handles disk and storage domain relations. The actual testing of multiple storage domain behavior should be handled in #51.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
