### PR TITLE
Re-adding name as a required VM creation parameter

### DIFF
--- a/client_disk_attachment_test.go
+++ b/client_disk_attachment_test.go
@@ -15,7 +15,8 @@ func TestDiskAttachmentCreation(t *testing.T) {
 	vm := assertCanCreateVM(
 		t,
 		helper,
-		ovirtclient.CreateVMParams().MustWithName(fmt.Sprintf("disk_attachment_test_%s", helper.GenerateRandomID(5))),
+		fmt.Sprintf("disk_attachment_test_%s", helper.GenerateRandomID(5)),
+		ovirtclient.CreateVMParams(),
 	)
 	disk := assertCanCreateDisk(t, client, helper)
 	assertDiskAttachmentCount(t, vm, 0)
@@ -32,12 +33,14 @@ func TestDiskAttachmentCannotBeAttachedToSecondVM(t *testing.T) {
 	vm1 := assertCanCreateVM(
 		t,
 		helper,
-		ovirtclient.CreateVMParams().MustWithName(fmt.Sprintf("disk_attachment_test_%s", helper.GenerateRandomID(5))),
+		fmt.Sprintf("disk_attachment_test_%s", helper.GenerateRandomID(5)),
+		ovirtclient.CreateVMParams(),
 	)
 	vm2 := assertCanCreateVM(
 		t,
 		helper,
-		ovirtclient.CreateVMParams().MustWithName(fmt.Sprintf("disk_attachment_test_%s", helper.GenerateRandomID(5))),
+		fmt.Sprintf("disk_attachment_test_%s", helper.GenerateRandomID(5)),
+		ovirtclient.CreateVMParams(),
 	)
 	disk := assertCanCreateDisk(t, client, helper)
 	_ = assertCanAttachDisk(t, vm1, disk)

--- a/client_nic_create_test.go
+++ b/client_nic_create_test.go
@@ -13,7 +13,8 @@ func TestVMNICCreation(t *testing.T) {
 	vm := assertCanCreateVM(
 		t,
 		helper,
-		ovirtclient.CreateVMParams().MustWithName(fmt.Sprintf("nic_test_%s", helper.GenerateRandomID(5))),
+		fmt.Sprintf("nic_test_%s", helper.GenerateRandomID(5)),
+		ovirtclient.CreateVMParams(),
 	)
 	assertNICCount(t, vm, 0)
 	nic := assertCanCreateNIC(t, helper, vm, "test", ovirtclient.CreateNICParams())

--- a/client_nic_update_test.go
+++ b/client_nic_update_test.go
@@ -13,7 +13,8 @@ func TestVMNICUpdate(t *testing.T) {
 	vm := assertCanCreateVM(
 		t,
 		helper,
-		ovirtclient.CreateVMParams().MustWithName(fmt.Sprintf("nic_test_%s", helper.GenerateRandomID(5))),
+		fmt.Sprintf("nic_test_%s", helper.GenerateRandomID(5)),
+		ovirtclient.CreateVMParams(),
 	)
 	assertNICCount(t, vm, 0)
 	nic := assertCanCreateNIC(t, helper, vm, "test", ovirtclient.CreateNICParams())

--- a/client_vm.go
+++ b/client_vm.go
@@ -15,6 +15,7 @@ type VMClient interface {
 	CreateVM(
 		clusterID string,
 		templateID string,
+		name string,
 		optional OptionalVMParameters,
 		retries ...RetryStrategy,
 	) (VM, error)
@@ -83,8 +84,6 @@ type VM interface {
 // OptionalVMParameters are a list of parameters that can be, but must not necessarily be added on VM creation. This
 // interface is expected to be extended in the future.
 type OptionalVMParameters interface {
-	// Name returns the name for the new VM.
-	Name() string
 	// Comment returns the comment for the VM.
 	Comment() string
 }
@@ -93,11 +92,6 @@ type OptionalVMParameters interface {
 // builder functions. This is placed here for future use.
 type BuildableVMParameters interface {
 	OptionalVMParameters
-
-	// WithName adds a name to the VM.
-	WithName(name string) (BuildableVMParameters, error)
-	// MustWithName is identical to WithName, but panics instead of returning an error.
-	MustWithName(name string) BuildableVMParameters
 
 	// WithComment adds a common to the VM.
 	WithComment(comment string) (BuildableVMParameters, error)

--- a/client_vm_test.go
+++ b/client_vm_test.go
@@ -22,7 +22,8 @@ func TestAfterVMCreationShouldBePresent(t *testing.T) {
 	vm, err := client.CreateVM(
 		helper.GetClusterID(),
 		helper.GetBlankTemplateID(),
-		ovirtclient.CreateVMParams().MustWithName("test"),
+		"test",
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -78,12 +79,14 @@ func TestAfterVMCreationShouldBePresent(t *testing.T) {
 func assertCanCreateVM(
 	t *testing.T,
 	helper ovirtclient.TestHelper,
+	name string,
 	params ovirtclient.OptionalVMParameters,
 ) ovirtclient.VM {
 	client := helper.GetClient()
 	vm, err := client.CreateVM(
 		helper.GetClusterID(),
 		helper.GetBlankTemplateID(),
+		name,
 		params,
 	)
 	if err != nil {

--- a/client_vm_update.go
+++ b/client_vm_update.go
@@ -16,6 +16,9 @@ func (o *oVirtClient) UpdateVM(
 	vm := &ovirtsdk.Vm{}
 	vm.SetId(id)
 	if name := params.Name(); name != nil {
+		if *name == "" {
+			return nil, newError(EBadArgument, "name must not be empty for VM update")
+		}
 		vm.SetName(*name)
 	}
 	if comment := params.Comment(); comment != nil {

--- a/example_vm_create_test.go
+++ b/example_vm_create_test.go
@@ -19,11 +19,13 @@ func ExampleVMClient_create() {
 	clusterID := helper.GetClusterID()
 	// Use the blank template as a starting point.
 	templateID := helper.GetBlankTemplateID()
+	// Set the VM name
+	name := "test-vm"
 	// Create the optional parameters.
 	params := ovirtclient.CreateVMParams()
 
 	// Create the VM...
-	vm, err := client.CreateVM(clusterID, templateID, params)
+	vm, err := client.CreateVM(clusterID, templateID, name, params)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create VM (%v)", err))
 	}

--- a/mock_vm_create.go
+++ b/mock_vm_create.go
@@ -4,11 +4,11 @@ import (
 	"github.com/google/uuid"
 )
 
-func (m *mockClient) CreateVM(clusterID string, templateID string, params OptionalVMParameters, _ ...RetryStrategy) (VM, error) {
+func (m *mockClient) CreateVM(clusterID string, templateID string, name string, params OptionalVMParameters, _ ...RetryStrategy) (VM, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if err := validateVMCreationParameters(clusterID, templateID, params); err != nil {
+	if err := validateVMCreationParameters(clusterID, templateID, name, params); err != nil {
 		return nil, err
 	}
 	if _, ok := m.clusters[clusterID]; !ok {
@@ -21,12 +21,15 @@ func (m *mockClient) CreateVM(clusterID string, templateID string, params Option
 	if params == nil {
 		params = &vmParams{}
 	}
+	if name == "" {
+		return nil, newError(EBadArgument, "The name parameter is required for VM creation.")
+	}
 
 	id := uuid.Must(uuid.NewUUID()).String()
 	vm := &vm{
 		client:     m,
 		id:         id,
-		name:       params.Name(),
+		name:       name,
 		comment:    params.Comment(),
 		clusterID:  clusterID,
 		templateID: templateID,


### PR DESCRIPTION
## Please describe the change you are making

The name parameter was erroneously removed as a required parameter in the past. This change re-adds the name parameter.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
