### PR TITLE
Added check to disallow removing disks from running VMs

### DIFF
--- a/mock_disk_remove.go
+++ b/mock_disk_remove.go
@@ -8,6 +8,14 @@ func (m *mockClient) RemoveDisk(diskID string, _ ...RetryStrategy) error {
 		return newError(ENotFound, "disk with ID %s not found", diskID)
 	}
 
+	// Check if disk is attached to a running VM
+	if diskAttachment, ok := m.diskAttachmentsByDisk[diskID]; ok {
+		vm := m.vms[diskAttachment.vmid]
+		if vm.status != VMStatusDown {
+			return newError(EConflict, "Disk %s is attached to VM %s", diskID, vm.id)
+		}
+	}
+
 	delete(m.diskAttachmentsByDisk, diskID)
 	delete(m.disks, diskID)
 


### PR DESCRIPTION
## Please describe the change you are making

This change adds a check to disallow removing disks that are currently attached to a running VM.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
