### PR TITLE
Removing builds on push on non-main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 17 * * 2'


### PR DESCRIPTION
## Please describe the change you are making

This PR removes builds on pushes to non-main branches to avoid CodeQL complains and conserve resources.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
