### PR TITLE
Fixing golangci-lint errors since 1.44.0 upgrade

### DIFF
--- a/client_disk_downloadimage_test.go
+++ b/client_disk_downloadimage_test.go
@@ -14,9 +14,7 @@ func TestImageDownload(t *testing.T) {
 	t.Parallel()
 	testImageData := getTestImageData(t)
 	fh, stat := getTestImageFile(t)
-	// We are ignoring G307/CWE-703 here because it's a short-lived test function and a file
-	// left open won't cause any problems.
-	defer func() { //nolint:gosec
+	defer func() {
 		_ = fh.Close()
 	}()
 

--- a/client_disk_uploadimage_test.go
+++ b/client_disk_uploadimage_test.go
@@ -9,9 +9,7 @@ import (
 
 func assertCanUploadDiskImage(t *testing.T, helper ovirtclient.TestHelper, disk ovirtclient.Disk) {
 	fh, stat := getTestImageFile(t)
-	// We are ignoring G307/CWE-703 here because it's a short-lived test function and a file
-	// left open won't cause any problems.
-	defer func() { //nolint:gosec
+	defer func() {
 		_ = fh.Close()
 	}()
 
@@ -34,9 +32,7 @@ func assertCanUploadDiskImage(t *testing.T, helper ovirtclient.TestHelper, disk 
 func TestImageUploadDiskCreated(t *testing.T) {
 	t.Parallel()
 	fh, stat := getTestImageFile(t)
-	// We are ignoring G307/CWE-703 here because it's a short-lived test function and a file
-	// left open won't cause any problems.
-	defer func() { //nolint:gosec
+	defer func() {
 		_ = fh.Close()
 	}()
 

--- a/example_vm_uploadimage_test.go
+++ b/example_vm_uploadimage_test.go
@@ -18,8 +18,7 @@ func ExampleDiskClient_uploadImage() {
 	if err != nil {
 		panic(fmt.Errorf("failed to open image file (%w)", err))
 	}
-	// Skip gosec linting because we are throwing a panic anyway.
-	defer func() { //nolint:gosec
+	defer func() {
 		if err = fh.Close(); err != nil {
 			panic(err)
 		}
@@ -58,8 +57,7 @@ func ExampleDiskClient_uploadImageWithCancel() {
 	if err != nil {
 		panic(fmt.Errorf("failed to open image file (%w)", err))
 	}
-	// Skip gosec linting because we are throwing a panic anyway.
-	defer func() { //nolint:gosec
+	defer func() {
 		if err = fh.Close(); err != nil {
 			panic(err)
 		}

--- a/scripts/rest.go
+++ b/scripts/rest.go
@@ -209,9 +209,7 @@ func handleTemplateFile(templateFileName string, id string, targetDir string, re
 	if err != nil {
 		return fmt.Errorf("failed to open %s (%w)", templateFileName, err)
 	}
-	// We are skipping gosec linting for G307/CWE-703 because this code is only used for
-	// generating code and the process will terminate in short order anyway.
-	defer func() { //nolint:gosec
+	defer func() {
 		_ = fh.Close()
 	}()
 	data, err := ioutil.ReadAll(fh)
@@ -265,13 +263,11 @@ func renderTemplate(tplText string, file string, restItem restItem) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse list template (%w)", err)
 	}
-	fh, err := os.Create(file)
+	fh, err := os.Create(file) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed to open %s (%w)", file, err)
 	}
-	// We are skipping gosec linting for G307/CWE-703 because this code is only used for
-	// generating code and the process will terminate in short order anyway.
-	defer func() { //nolint:gosec
+	defer func() {
 		if err := fh.Close(); err != nil {
 			panic(fmt.Errorf("failed to close %s (%w)", file, err))
 		}


### PR DESCRIPTION
## Please describe the change you are making

This change fixes the linting errors introduced in golangci-lint 1.44.0.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
