### PR TITLE
Fixes #110: No more failure on missing initialization

### DIFF
--- a/client_vm.go
+++ b/client_vm.go
@@ -191,10 +191,13 @@ func (i *initialization) WithHostname(hostname string) BuildableInitialization {
 	return i
 }
 
-func convertSDKInitialization(sdkObject *ovirtsdk.Vm) (*initialization, error) {
+// convertSDKInitialization converts the initialization of a VM. We keep the error return in case we need it later
+// as errors may happen as we extend this function and we don't want to touch other functions.
+func convertSDKInitialization(sdkObject *ovirtsdk.Vm) (*initialization, error) { //nolint:unparam
 	initializationSDK, ok := sdkObject.Initialization()
 	if !ok {
-		return nil, newFieldNotFound("VM", "initialization")
+		// This happens for some, but not all API calls if the initialization is not set.
+		return &initialization{}, nil
 	}
 
 	init := initialization{}

--- a/client_vm_test.go
+++ b/client_vm_test.go
@@ -217,6 +217,21 @@ func assertCanCreateVM(
 	return assertCanCreateVMFromTemplate(t, helper, name, helper.GetBlankTemplateID(), params)
 }
 
+func TestVMWithoutInitialization(t *testing.T) {
+	helper := getHelper(t)
+
+	vm := assertCanCreateVM(t, helper, fmt.Sprintf("test_%s", helper.GenerateRandomID(5)), nil)
+
+	vm, err := helper.GetClient().GetVM(vm.ID())
+	if err != nil {
+		t.Fatalf("Failed to re-fetch VM after creation (%v)", err)
+	}
+
+	if vm.Initialization() == nil {
+		t.Fatalf("Initialization is nil on VM without initialization.")
+	}
+}
+
 func assertCanCreateVMFromTemplate(
 	t *testing.T,
 	helper ovirtclient.TestHelper,

--- a/mock_vm_create.go
+++ b/mock_vm_create.go
@@ -71,6 +71,10 @@ func (m *mockClient) createVM(
 	cpu *vmCPU,
 ) *vm {
 	id := uuid.Must(uuid.NewUUID()).String()
+	init := params.Initialization()
+	if init == nil {
+		init = &initialization{}
+	}
 	vm := &vm{
 		client:         m,
 		id:             id,
@@ -81,7 +85,7 @@ func (m *mockClient) createVM(
 		status:         VMStatusDown,
 		cpu:            cpu,
 		hugePages:      params.HugePages(),
-		initialization: params.Initialization(),
+		initialization: init,
 	}
 	m.vms[id] = vm
 	return vm


### PR DESCRIPTION
## Please describe the change you are making

Before this fix the GET / LIST calls for VMs would fail with the message "no initialization field found on VM object" if there is no initialization set. However, creation would not fail. This change fixes that issue and adds a test to make sure this is actually fixed. The test has been verified against the oVirt engine.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
