### PR TITLE
add workflow and spec file for tests packing

### DIFF
--- a/.github/workflows/compile-and-pack-tests.yml
+++ b/.github/workflows/compile-and-pack-tests.yml
@@ -1,0 +1,41 @@
+name: go-ovirt-client compilation with current patch
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+jobs:
+  compile-and-build-rpm:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream8
+    steps:
+      - name: prepare env
+        run: |
+           yum install -y git createrepo_c rpm-build golang make
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name : Compile go-ovirt-client tests and Build go-ovirt-client-tests RPM
+        run: |
+          echo "::group::Generating suffix..."
+          SUFFIX=.$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)
+          echo "::endgroup::"
+
+          mkdir -p go-ovirt-client-tests-bin
+          go test -v -c -o go-ovirt-client-tests-bin/go-ovirt-client-tests-exe
+
+          mkdir -p BUILDROOT SOURCES
+          cp go-ovirt-client-tests-bin/go-ovirt-client-tests-exe SOURCES/
+          tar cvzf go-ovirt-client-tests.tar.gz go-ovirt-client-tests-bin/
+          cp go-ovirt-client-tests.tar.gz SOURCES
+          rpmbuild -D "_topdir $(pwd)" -D "release_suffix ${SUFFIX}" -bb go-ovirt-client-tests.spec
+      - name: Collect artifacts
+        run: |
+          mkdir -p exported-artifacts
+          find . -iname \*rpm -exec mv "{}" exported-artifacts/ \;
+          ls -l exported-artifacts
+      - name: Upload artifacts
+        uses: ovirt/upload-rpms-action@main
+        with:
+          directory: exported-artifacts

--- a/go-ovirt-client-tests.spec
+++ b/go-ovirt-client-tests.spec
@@ -1,0 +1,23 @@
+Name:		go-ovirt-client-tests
+Version:	1.0.0
+Release:	0.0.master%{?release_suffix}%{?dist}
+License:	ASL 2.0
+Summary:	go ovirt client with current patch
+Group:		Virtualization/Management
+URL:		https://github.com/oVirt/go-ovirt-client
+BuildArch:	x86_64
+Source:         go-ovirt-client-tests.tar.gz
+
+%description
+go ovirt client tests binary compiled with current patch
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+cp %{_sourcedir}/go-ovirt-client-tests-exe %{buildroot}/usr/bin/
+
+%files
+/usr/bin/go-ovirt-client-tests-exe
+
+%changelog
+* Sun Mar 20 2022 Eli Mesika <emesika@redhat.com> 1.0.0
+- Created


### PR DESCRIPTION
Adding a workflow and spec file to compile go-ovirt-client
tests to a binary file and deploy it as go-ovirt-client-tests RPM

## Please describe the change you are making

...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

...
