### PR TITLE
Fixes #129: Sparse support on VM creation

### DIFF
--- a/client_disk_attachment_test.go
+++ b/client_disk_attachment_test.go
@@ -48,13 +48,22 @@ func TestDiskAttachmentCannotBeAttachedToSecondVM(t *testing.T) {
 }
 
 func assertCanCreateDisk(t *testing.T, helper ovirtclient.TestHelper) ovirtclient.Disk {
+	return assertCanCreateDiskWithParameters(t, helper, ovirtclient.ImageFormatRaw, nil)
+}
+
+func assertCanCreateDiskWithParameters(
+	t *testing.T,
+	helper ovirtclient.TestHelper,
+	format ovirtclient.ImageFormat,
+	parameters ovirtclient.CreateDiskOptionalParameters,
+) ovirtclient.Disk {
 	t.Logf("Creating test disk...")
 	client := helper.GetClient()
 	disk, err := client.CreateDisk(
 		helper.GetStorageDomainID(),
-		ovirtclient.ImageFormatRaw,
-		512,
-		nil,
+		format,
+		1048576,
+		parameters,
 	)
 	if disk != nil {
 		t.Cleanup(

--- a/client_disk_test.go
+++ b/client_disk_test.go
@@ -22,8 +22,8 @@ func ExampleDiskClient_CreateDisk() {
 	storageDomainID := helper.GetStorageDomainID()
 	// Let's create a raw disk.
 	imageFormat := ovirtclient.ImageFormatRaw
-	// 512 bytes are enough.
-	diskSize := 512
+	// 512 bytes are enough, 1M is the minimum disk size for oVirt.
+	diskSize := 1048576
 
 	// Create the disk and wait for it to become available. Use StartCreateDisk to skip the wait.
 	disk, err := client.CreateDisk(
@@ -53,7 +53,7 @@ func TestDiskCreationAndUpdate(t *testing.T) {
 	disk, err := client.CreateDisk(
 		helper.GetStorageDomainID(),
 		ovirtclient.ImageFormatRaw,
-		512,
+		1048576,
 		ovirtclient.CreateDiskParams().MustWithAlias(diskName),
 	)
 	if err != nil {

--- a/client_disk_uploadimage.go
+++ b/client_disk_uploadimage.go
@@ -108,13 +108,13 @@ func (o *oVirtClient) StartUploadToDisk(
 	}
 
 	// TBD: Should we automatically increase the size of the disk here?
-	if size > disk.TotalSize() {
+	if size > disk.ProvisionedSize() {
 		return nil, newError(
 			EBadArgument,
 			"the specified size (%d bytes) is larger than the target disk %s (%d bytes)",
 			size,
 			diskID,
-			disk.TotalSize(),
+			disk.ProvisionedSize(),
 		)
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/client_disk_uploadimage_test.go
+++ b/client_disk_uploadimage_test.go
@@ -64,7 +64,7 @@ func TestImageUploadToExistingDisk(t *testing.T) {
 	disk, err := client.CreateDisk(
 		helper.GetStorageDomainID(),
 		ovirtclient.ImageFormatRaw,
-		uint64(512),
+		uint64(1048576),
 		ovirtclient.CreateDiskParams().MustWithSparse(true).MustWithAlias(imageName),
 	)
 	if disk != nil {

--- a/client_vm.go
+++ b/client_vm.go
@@ -404,6 +404,9 @@ type OptionalVMParameters interface {
 
 	// Memory returns the VM memory in Bytes.
 	Memory() *int64
+
+	// Disks returns a list of disks that are to be changed from the template.
+	Disks() []OptionalVMDiskParameters
 }
 
 // BuildableVMParameters is a variant of OptionalVMParameters that can be changed using the supplied
@@ -447,6 +450,106 @@ type BuildableVMParameters interface {
 	WithClone(clone bool) (BuildableVMParameters, error)
 	// MustWithClone is identical to WithClone, but panics instead of returning an error.
 	MustWithClone(clone bool) BuildableVMParameters
+
+	// WithDisks adds disk configurations to the VM creation to manipulate the disks inherited from templates.
+	WithDisks(disks []OptionalVMDiskParameters) (BuildableVMParameters, error)
+	// MustWithDisks is identical to WithDisks, but panics instead of returning an error.
+	MustWithDisks(disks []OptionalVMDiskParameters) BuildableVMParameters
+}
+
+// OptionalVMDiskParameters describes the disk parameters that can be given to VM creation. These manipulate the
+// disks inherited from the template.
+type OptionalVMDiskParameters interface {
+	// DiskID returns the identifier of the disk that is being changed.
+	DiskID() string
+	// Sparse sets the sparse parameter if set. Note, that Sparse is only supported in oVirt on block devices with QCOW2
+	// images. On NFS you MUST use raw disks to use sparse.
+	Sparse() *bool
+	// Format returns the image format to be used for the specified disk.
+	Format() *ImageFormat
+}
+
+// BuildableVMDiskParameters is a buildable version of OptionalVMDiskParameters.
+type BuildableVMDiskParameters interface {
+	OptionalVMDiskParameters
+
+	// WithSparse enables or disables sparse disk provisioning. Note, that Sparse is only supported in oVirt on block
+	// devices with QCOW2 images. On NFS you MUST use raw images to use sparse. See WithFormat.
+	WithSparse(sparse bool) (BuildableVMDiskParameters, error)
+	// MustWithSparse is identical to WithSparse, but panics instead of returning an error.
+	MustWithSparse(sparse bool) BuildableVMDiskParameters
+
+	// WithFormat adds a disk format to the VM on creation. Note, that QCOW2 is only supported in conjunction with
+	// Sparse on block devices. On NFS you MUST use raw images to use sparse. See WithSparse.
+	WithFormat(format ImageFormat) (BuildableVMDiskParameters, error)
+	// MustWithFormat is identical to WithFormat, but panics instead of returning an error.
+	MustWithFormat(format ImageFormat) BuildableVMDiskParameters
+}
+
+// NewBuildableVMDiskParameters creates a new buildable OptionalVMDiskParameters.
+func NewBuildableVMDiskParameters(diskID string) (BuildableVMDiskParameters, error) {
+	return &vmDiskParameters{
+		diskID,
+		nil,
+		nil,
+	}, nil
+}
+
+// MustNewBuildableVMDiskParameters is identical to NewBuildableVMDiskParameters but panics instead of returning an
+// error.
+func MustNewBuildableVMDiskParameters(diskID string) BuildableVMDiskParameters {
+	builder, err := NewBuildableVMDiskParameters(diskID)
+	if err != nil {
+		panic(err)
+	}
+	return builder
+}
+
+type vmDiskParameters struct {
+	diskID string
+	sparse *bool
+	format *ImageFormat
+}
+
+func (v *vmDiskParameters) Format() *ImageFormat {
+	return v.format
+}
+
+func (v *vmDiskParameters) WithFormat(format ImageFormat) (BuildableVMDiskParameters, error) {
+	if err := format.Validate(); err != nil {
+		return nil, err
+	}
+	v.format = &format
+	return v, nil
+}
+
+func (v *vmDiskParameters) MustWithFormat(format ImageFormat) BuildableVMDiskParameters {
+	builder, err := v.WithFormat(format)
+	if err != nil {
+		panic(err)
+	}
+	return builder
+}
+
+func (v *vmDiskParameters) DiskID() string {
+	return v.diskID
+}
+
+func (v *vmDiskParameters) Sparse() *bool {
+	return v.sparse
+}
+
+func (v *vmDiskParameters) WithSparse(sparse bool) (BuildableVMDiskParameters, error) {
+	v.sparse = &sparse
+	return v, nil
+}
+
+func (v *vmDiskParameters) MustWithSparse(sparse bool) BuildableVMDiskParameters {
+	builder, err := v.WithSparse(sparse)
+	if err != nil {
+		panic(err)
+	}
+	return builder
 }
 
 // UpdateVMParameters returns a set of parameters to change on a VM.
@@ -607,6 +710,8 @@ type vmParams struct {
 	memory         *int64
 
 	clone *bool
+
+	disks []OptionalVMDiskParameters
 }
 
 func (v *vmParams) Clone() *bool {
@@ -620,6 +725,35 @@ func (v *vmParams) WithClone(clone bool) (BuildableVMParameters, error) {
 
 func (v *vmParams) MustWithClone(clone bool) BuildableVMParameters {
 	builder, err := v.WithClone(clone)
+	if err != nil {
+		panic(err)
+	}
+	return builder
+}
+
+func (v *vmParams) Disks() []OptionalVMDiskParameters {
+	return v.disks
+}
+
+func (v *vmParams) WithDisks(disks []OptionalVMDiskParameters) (BuildableVMParameters, error) {
+	diskIDs := map[string]int{}
+	for i, d := range disks {
+		if previousID, ok := diskIDs[d.DiskID()]; ok {
+			return nil, newError(
+				EBadArgument,
+				"Disk %s appears twice, in position %d and %d.",
+				d.DiskID(),
+				previousID,
+				i,
+			)
+		}
+	}
+	v.disks = disks
+	return v, nil
+}
+
+func (v *vmParams) MustWithDisks(disks []OptionalVMDiskParameters) BuildableVMParameters {
+	builder, err := v.WithDisks(disks)
 	if err != nil {
 		panic(err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db h1:ahvAlEurj4TF1SEx
 github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
 github.com/ovirt/go-ovirt-client-log/v2 v2.2.0 h1:7iZQs+8moX7aopeAdNU1b12mF/yWWBVA/Pey55F9PTQ=
 github.com/ovirt/go-ovirt-client-log/v2 v2.2.0/go.mod h1:mDoU3KIwftpsgZGzXGk5d2UEJYTY0bYMfg/GwPapXL0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -13,7 +15,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+github.com/zchee/go-qcow2 v0.0.0-20170102190316-9a991fd172f0 h1:dyzM+LWIb64QGUsDUZ2y6e2NkkqejOv8PEv05ajx1co=
+github.com/zchee/go-qcow2 v0.0.0-20170102190316-9a991fd172f0/go.mod h1:XO8ymgJzGFNntEd5L8yc0l1wyz3T5DbQD4lguyldfMA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mock_disk.go
+++ b/mock_disk.go
@@ -73,7 +73,10 @@ func (d *diskWithData) withProvisionedSize(ps uint64) (*diskWithData, error) {
 }
 
 // clone is an internal function that makes a copy of the disk object with a new UUID.
-func (d *diskWithData) clone() *diskWithData {
+func (d *diskWithData) clone(sparse *bool) *diskWithData {
+	if sparse == nil {
+		sparse = &d.sparse
+	}
 	return &diskWithData{
 		disk{
 			d.client,
@@ -84,7 +87,7 @@ func (d *diskWithData) clone() *diskWithData {
 			d.storageDomainIDs,
 			d.status,
 			d.totalSize,
-			d.sparse,
+			*sparse,
 		},
 		&sync.Mutex{},
 		d.data,

--- a/mock_disk_downloadimage.go
+++ b/mock_disk_downloadimage.go
@@ -25,7 +25,7 @@ func (m *mockClient) StartDownloadDisk(diskID string, format ImageFormat, _ ...R
 	}
 
 	if disk.format != format {
-		return nil, newError(EBug, "the mock library doesn't support converting images from %s to %s; please download images in the same format as you uploaded them", disk.format, format)
+		m.logger.Warningf("the image upload client requested a conversion from from %s to %s; the mock library does not support this and the source image data will be used unmodified which may lead to errors", disk.format, format)
 	}
 
 	dl := &mockImageDownload{
@@ -42,7 +42,7 @@ func (m *mockClient) StartDownloadDisk(diskID string, format ImageFormat, _ ...R
 	return dl, nil
 }
 
-// Deprecated: use DownloadImage instead.
+// Deprecated: use DownloadDisk instead.
 func (m *mockClient) DownloadImage(diskID string, format ImageFormat, retries ...RetryStrategy) (
 	ImageDownloadReader,
 	error,

--- a/mock_template_create.go
+++ b/mock_template_create.go
@@ -72,7 +72,7 @@ func (m *mockClient) attachTemplateDisks(vmID string, tpl *template) {
 	i := 0
 	for _, attachment := range m.vmDiskAttachmentsByVM[vmID] {
 		disk := m.disks[attachment.diskID]
-		newDisk := disk.clone()
+		newDisk := disk.clone(nil)
 		_ = newDisk.Lock()
 		newDisk.alias = fmt.Sprintf("disk-%s", generateRandomID(5, m.nonSecureRandom))
 		m.disks[newDisk.ID()] = newDisk


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes #129 and adds the sparse flag for creating virtual machines.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
