### PR TITLE
Add trigger for go-ovirt-client-tests suite

### DIFF
--- a/.github/workflows/go-ovirt-client-tests-suite-trigger.yaml
+++ b/.github/workflows/go-ovirt-client-tests-suite-trigger.yaml
@@ -1,0 +1,21 @@
+name: OST go-ovirt-client-tests-suite trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-ost:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ost') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
+    with:
+      pr_url: ${{ github.event.issue.pull_request.url }}
+      suite: go-ovirt-client-tests-suite-master
+      distro: el8stream
+

--- a/.github/workflows/go-ovirt-client-tests-suite-trigger.yaml
+++ b/.github/workflows/go-ovirt-client-tests-suite-trigger.yaml
@@ -6,16 +6,6 @@ on:
 
 jobs:
   trigger-ost:
-    if: |
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/ost') &&
-      (
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
-      )
     uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
-    with:
-      pr_url: ${{ github.event.issue.pull_request.url }}
-      suite: go-ovirt-client-tests-suite-master
-      distro: el8stream
-
+      with:
+        comment: " tr-suite-master"


### PR DESCRIPTION
Adds a trigger file that will trigger execution in OST of the
go-ovirt-client-tests-suite-master suite

## Please describe the change you are making

...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

...
