### PR TITLE
Fixes #55: Incorrect oVirt Engine API URL not correctly identified

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -230,12 +230,24 @@ func realIdentify(err error) EngineError {
 	var authErr *ovirtsdk.AuthError
 	var notFoundErr *ovirtsdk.NotFoundError
 	switch {
+	case strings.Contains(err.Error(), "stopped after") && strings.Contains(err.Error(), "redirects"):
+		return wrap(
+			err,
+			ENotAnOVirtEngine,
+			"the specified oVirt Engine URL has resulted in a redirect, check if your URL is correct",
+		)
 	case strings.Contains(err.Error(), "parse non-array sso with response"):
-		return wrap(err,
-			ENotAnOVirtEngine, "invalid credentials, or the URL does not point to an oVirt Engine, check your settings")
+		return wrap(
+			err,
+			ENotAnOVirtEngine,
+			"invalid credentials, or the URL does not point to an oVirt Engine, check your settings",
+		)
 	case strings.Contains(err.Error(), "server gave HTTP response to HTTPS client"):
-		return wrap(err,
-			ENotAnOVirtEngine, "the server gave a HTTP response to a HTTPS client, check if your URL is correct")
+		return wrap(
+			err,
+			ENotAnOVirtEngine,
+			"the server gave a HTTP response to a HTTPS client, check if your URL is correct",
+		)
 	case strings.Contains(err.Error(), "tls"):
 		fallthrough
 	case strings.Contains(err.Error(), "x509"):

--- a/test_helper.go
+++ b/test_helper.go
@@ -38,6 +38,12 @@ type TestHelper interface {
 
 	// GetTLS returns the TLS provider used for this test helper.
 	GetTLS() TLSProvider
+
+	// GetUsername returns the oVirt username.
+	GetUsername() string
+
+	// GetPassword returns the oVirt password.
+	GetPassword() string
 }
 
 // MustNewTestHelper is identical to NewTestHelper, but panics instead of returning an error.
@@ -114,6 +120,8 @@ func NewTestHelper(
 	}
 
 	return &testHelper{
+		username:                 username,
+		password:                 password,
 		client:                   client,
 		tls:                      tlsProvider,
 		clusterID:                clusterID,
@@ -405,6 +413,16 @@ type testHelper struct {
 	blankTemplateID          TemplateID
 	vnicProfileID            string
 	secondaryStorageDomainID string
+	password                 string
+	username                 string
+}
+
+func (t *testHelper) GetUsername() string {
+	return t.username
+}
+
+func (t *testHelper) GetPassword() string {
+	return t.password
 }
 
 func (t *testHelper) GetSecondaryStorageDomainID(te *testing.T) string {


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes #55 and correctly identifies bad oVirt engine URLs with redirects.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
