### PR TITLE
Fixes #151: automatic recovery from invalid_grant failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters-settings:
     include-go-root: false
     packages:
       - github.com/ovirt/go-ovirt
-      - github.com/ovirt/go-ovirt-client-log/v2
+      - github.com/ovirt/go-ovirt-client-log/v3
       - github.com/google/uuid
   govet:
     enable-all: true

--- a/affinitygroup_create.go
+++ b/affinitygroup_create.go
@@ -15,7 +15,7 @@ func (o *oVirtClient) CreateAffinityGroup(
 	if params == nil {
 		params = CreateAffinityGroupParams()
 	}
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("creating affinity group in cluster %s", clusterID),
 		o.logger,

--- a/affinitygroup_get.go
+++ b/affinitygroup_get.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) GetAffinityGroup(clusterID ClusterID, id AffinityGroupID, retries ...RetryStrategy) (result AffinityGroup, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting affinity group %s", id),
 		o.logger,
@@ -40,7 +40,7 @@ func (o *oVirtClient) GetAffinityGroup(clusterID ClusterID, id AffinityGroupID, 
 
 func (m *mockClient) GetAffinityGroup(clusterID ClusterID, id AffinityGroupID, retries ...RetryStrategy) (result AffinityGroup, err error) {
 
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(m))
 
 	err = retry(
 		fmt.Sprintf("getting affinity group %s from cluster %s", id, clusterID),

--- a/affinitygroup_get_by_name.go
+++ b/affinitygroup_get_by_name.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetAffinityGroupByName(clusterID ClusterID, name string, retries ...RetryStrategy) (result AffinityGroup, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting affinity group %s", name),
 		o.logger,
@@ -55,7 +55,7 @@ func (o *oVirtClient) GetAffinityGroupByName(clusterID ClusterID, name string, r
 
 func (m *mockClient) GetAffinityGroupByName(clusterID ClusterID, name string, retries ...RetryStrategy) (result AffinityGroup, err error) {
 
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(m))
 
 	err = retry(
 		fmt.Sprintf("getting affinity group %s from cluster %s", name, clusterID),

--- a/affinitygroup_list.go
+++ b/affinitygroup_list.go
@@ -6,7 +6,7 @@ func (o *oVirtClient) ListAffinityGroups(
 	clusterID ClusterID,
 	retries ...RetryStrategy,
 ) (result []AffinityGroup, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []AffinityGroup{}
 	err = retry(
 		fmt.Sprintf("listing affinity groups in cluster %s", clusterID),

--- a/affinitygroup_remove.go
+++ b/affinitygroup_remove.go
@@ -3,7 +3,7 @@ package ovirtclient
 import "fmt"
 
 func (o *oVirtClient) RemoveAffinityGroup(clusterID ClusterID, id AffinityGroupID, retries ...RetryStrategy) error {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	return retry(
 		fmt.Sprintf("removing affinity group %s from cluster %s", id, clusterID),
 		o.logger,
@@ -24,7 +24,7 @@ func (o *oVirtClient) RemoveAffinityGroup(clusterID ClusterID, id AffinityGroupI
 
 func (m *mockClient) RemoveAffinityGroup(clusterID ClusterID, id AffinityGroupID, retries ...RetryStrategy) error {
 
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(m))
 
 	return retry(
 		fmt.Sprintf("removing affinity group %s from cluster %s", id, clusterID),

--- a/affinitygroup_vm_add.go
+++ b/affinitygroup_vm_add.go
@@ -13,7 +13,7 @@ func (o *oVirtClient) AddVMToAffinityGroup(
 	agID AffinityGroupID,
 	retries ...RetryStrategy,
 ) error {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	vm, err := ovirtsdk4.NewVmBuilder().Id(vmID).Build()
 	if err != nil {
 		return wrap(err, EBug, "Failed to build SDK VM object")

--- a/affinitygroup_vm_remove.go
+++ b/affinitygroup_vm_remove.go
@@ -10,7 +10,7 @@ func (o *oVirtClient) RemoveVMFromAffinityGroup(
 	agID AffinityGroupID,
 	retries ...RetryStrategy,
 ) error {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	return retry(
 		fmt.Sprintf("adding VM %s to affinity group %s", vmID, agID),
 		o.logger,

--- a/client_cluster_get.go
+++ b/client_cluster_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetCluster(id ClusterID, retries ...RetryStrategy) (result Cluster, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting cluster %s", id),
 		o.logger,

--- a/client_cluster_list.go
+++ b/client_cluster_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListClusters(retries ...RetryStrategy) (result []Cluster, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Cluster{}
 	err = retry(
 		"listing clusters",

--- a/client_datacenter_get.go
+++ b/client_datacenter_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetDatacenter(id string, retries ...RetryStrategy) (result Datacenter, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting datacenter %s", id),
 		o.logger,

--- a/client_datacenter_list.go
+++ b/client_datacenter_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListDatacenters(retries ...RetryStrategy) (result []Datacenter, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Datacenter{}
 	err = retry(
 		"listing datacenters",

--- a/client_datacenter_list_clusters.go
+++ b/client_datacenter_list_clusters.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) ListDatacenterClusters(id string, retries ...RetryStrategy) (result []Cluster, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Cluster{}
 	err = retry(
 		fmt.Sprintf("listing datacenters %s clusters", id),

--- a/client_disk.go
+++ b/client_disk.go
@@ -796,7 +796,7 @@ func (d *diskWait) Disk() Disk {
 }
 
 func (d *diskWait) Wait(retries ...RetryStrategy) (Disk, error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(d.client))
 	if err := d.client.waitForJobFinished(d.correlationID, retries); err != nil {
 		return d.disk, err
 	}

--- a/client_disk_attachment_create.go
+++ b/client_disk_attachment_create.go
@@ -13,7 +13,7 @@ func (o *oVirtClient) CreateDiskAttachment(
 	params CreateDiskAttachmentOptionalParams,
 	retries ...RetryStrategy,
 ) (result DiskAttachment, err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	if err := diskInterface.Validate(); err != nil {
 		return nil, wrap(err, EBadArgument, "failed to create disk attachment")
 	}

--- a/client_disk_attachment_get.go
+++ b/client_disk_attachment_get.go
@@ -9,7 +9,7 @@ func (o *oVirtClient) GetDiskAttachment(
 	id string,
 	retries ...RetryStrategy,
 ) (result DiskAttachment, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting disk attachment %s on VM %s", id, vmid),
 		o.logger,

--- a/client_disk_attachment_list.go
+++ b/client_disk_attachment_list.go
@@ -8,7 +8,7 @@ func (o *oVirtClient) ListDiskAttachments(
 	vmid string,
 	retries ...RetryStrategy,
 ) (result []DiskAttachment, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []DiskAttachment{}
 	err = retry(
 		fmt.Sprintf("listing disk attachments on VM %s", vmid),

--- a/client_disk_attachment_remove.go
+++ b/client_disk_attachment_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveDiskAttachment(vmID string, diskAttachmentID string, retries ...RetryStrategy) error {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	return retry(
 		fmt.Sprintf("removing disk attachment %s on VM %s", diskAttachmentID, vmID),
 		o.logger,

--- a/client_disk_create.go
+++ b/client_disk_create.go
@@ -14,7 +14,7 @@ func (o *oVirtClient) StartCreateDisk(
 	params CreateDiskOptionalParameters,
 	retries ...RetryStrategy,
 ) (DiskCreation, error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 
 	if err := validateDiskCreationParameters(format, size); err != nil {
 		return nil, err
@@ -139,8 +139,8 @@ func (o *oVirtClient) CreateDisk(
 	params CreateDiskOptionalParameters,
 	retries ...RetryStrategy,
 ) (Disk, error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
-	waitRetries := defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
+	waitRetries := defaultRetries(retries, defaultLongTimeouts(o))
 	result, err := o.StartCreateDisk(storageDomainID, format, size, params, retries...)
 	if err != nil {
 		return nil, err

--- a/client_disk_downloadimage.go
+++ b/client_disk_downloadimage.go
@@ -18,7 +18,7 @@ func (o *oVirtClient) StartImageDownload(diskID string, format ImageFormat, retr
 }
 
 func (o *oVirtClient) StartDownloadDisk(diskID string, format ImageFormat, retries ...RetryStrategy) (ImageDownload, error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 
 	o.logger.Infof("Starting disk %s image download...", diskID)
 	disk, err := o.GetDisk(diskID)

--- a/client_disk_get.go
+++ b/client_disk_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetDisk(id string, retries ...RetryStrategy) (result Disk, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting disk %s", id),
 		o.logger,

--- a/client_disk_list.go
+++ b/client_disk_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListDisks(retries ...RetryStrategy) (result []Disk, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Disk{}
 	err = retry(
 		"listing disks",

--- a/client_disk_list_by_alias.go
+++ b/client_disk_list_by_alias.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) ListDisksByAlias(alias string, retries ...RetryStrategy) (result []Disk, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Disk{}
 	err = retry(
 		fmt.Sprintf("listing disk by alias %s", alias),

--- a/client_disk_remove.go
+++ b/client_disk_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveDisk(diskID string, retries ...RetryStrategy) error {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	return retry(
 		fmt.Sprintf("removing disk %s", diskID),
 		o.logger,

--- a/client_disk_test.go
+++ b/client_disk_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 // ExampleDiskClient_CreateDisk is an example of creating an empty disk. This example works with the test

--- a/client_disk_update.go
+++ b/client_disk_update.go
@@ -22,7 +22,7 @@ func (o *oVirtClient) StartUpdateDisk(id string, params UpdateDiskParameters, re
 	DiskUpdate,
 	error,
 ) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 
 	sdkDisk := ovirtsdk.NewDiskBuilder().Id(id)
 	if alias := params.Alias(); alias != nil {

--- a/client_disk_uploadimage.go
+++ b/client_disk_uploadimage.go
@@ -42,7 +42,7 @@ func (o *oVirtClient) UploadToNewDisk(
 	reader io.ReadSeekCloser,
 	retries ...RetryStrategy,
 ) (UploadImageResult, error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 	progress, err := o.StartUploadToNewDisk(storageDomainID, format, size, params, reader, retries...)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (o *oVirtClient) UploadToDisk(
 	reader io.ReadSeekCloser,
 	retries ...RetryStrategy,
 ) error {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 	progress, err := o.StartUploadToDisk(diskID, size, reader, retries...)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (o *oVirtClient) StartUploadToDisk(
 	reader io.ReadSeekCloser,
 	retries ...RetryStrategy,
 ) (UploadImageProgress, error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	o.logger.Infof("Starting disk image upload...")
 	disk, err := o.GetDisk(diskID, retries...)
 	if err != nil {
@@ -302,7 +302,7 @@ func (o *oVirtClient) StartUploadToNewDisk(
 	reader io.ReadSeekCloser,
 	retries ...RetryStrategy,
 ) (UploadImageProgress, error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 
 	o.logger.Infof("Starting disk image upload...")
 

--- a/client_host_get.go
+++ b/client_host_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetHost(id string, retries ...RetryStrategy) (result Host, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting host %s", id),
 		o.logger,

--- a/client_host_list.go
+++ b/client_host_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListHosts(retries ...RetryStrategy) (result []Host, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Host{}
 	err = retry(
 		"listing hosts",

--- a/client_network_get.go
+++ b/client_network_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetNetwork(id string, retries ...RetryStrategy) (result Network, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting network %s", id),
 		o.logger,

--- a/client_network_list.go
+++ b/client_network_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListNetworks(retries ...RetryStrategy) (result []Network, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Network{}
 	err = retry(
 		"listing networks",

--- a/client_nic_create.go
+++ b/client_nic_create.go
@@ -17,7 +17,7 @@ func (o *oVirtClient) CreateNIC(
 		return nil, err
 	}
 
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("creating NIC for VM %s", vmid),
 		o.logger,

--- a/client_nic_get.go
+++ b/client_nic_get.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) GetNIC(vmid string, id string, retries ...RetryStrategy) (result NIC, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting NIC %s for VM %s", id, vmid),
 		o.logger,

--- a/client_nic_list.go
+++ b/client_nic_list.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) ListNICs(vmid string, retries ...RetryStrategy) (result []NIC, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("listing NICs for VM %s", vmid),
 		o.logger,

--- a/client_nic_remove.go
+++ b/client_nic_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveNIC(vmid string, id string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing NIC %s from VM %s", id, vmid),
 		o.logger,

--- a/client_nic_update.go
+++ b/client_nic_update.go
@@ -24,7 +24,7 @@ func (o *oVirtClient) UpdateNIC(
 
 	req.Nic(nicBuilder.MustBuild())
 
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("updating NIC %s for VM %s", nicID, vmid),
 		o.logger,

--- a/client_storagedomain.go
+++ b/client_storagedomain.go
@@ -322,7 +322,7 @@ func (d *storageDomainDiskWait) Disk() Disk {
 }
 
 func (d *storageDomainDiskWait) Wait(retries ...RetryStrategy) (Disk, error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(d.client))
 	d.lock.Lock()
 	diskID := d.disk.ID()
 	storageDomainID := d.storageDomain.ID()

--- a/client_storagedomain_get.go
+++ b/client_storagedomain_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetStorageDomain(id string, retries ...RetryStrategy) (result StorageDomain, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting storage domain %s", id),
 		o.logger,

--- a/client_storagedomain_get_disk.go
+++ b/client_storagedomain_get_disk.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) GetDiskFromStorageDomain(id string, diskID string, retries ...RetryStrategy) (result Disk, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting disk %s from storage domain %s", diskID, id),
 		o.logger,

--- a/client_storagedomain_list.go
+++ b/client_storagedomain_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListStorageDomains(retries ...RetryStrategy) (result []StorageDomain, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []StorageDomain{}
 	err = retry(
 		"listing storage domains",

--- a/client_storagedomain_remove_disk.go
+++ b/client_storagedomain_remove_disk.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveDiskFromStorageDomain(id string, diskID string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing disk %s from storage domain %s", diskID, id),
 		o.logger,

--- a/client_tag_create.go
+++ b/client_tag_create.go
@@ -3,7 +3,7 @@ package ovirtclient
 import ovirtsdk "github.com/ovirt/go-ovirt"
 
 func (o *oVirtClient) CreateTag(name string, params CreateTagParams, retries ...RetryStrategy) (result Tag, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	if params == nil {
 		params = NewCreateTagParams()
 	}

--- a/client_tag_get.go
+++ b/client_tag_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetTag(id string, retries ...RetryStrategy) (result Tag, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting tag %s", id),
 		o.logger,

--- a/client_tag_list.go
+++ b/client_tag_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListTags(retries ...RetryStrategy) (result []Tag, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Tag{}
 	err = retry(
 		"listing tags",

--- a/client_tag_remove.go
+++ b/client_tag_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveTag(tagID string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing tag %s", tagID),
 		o.logger,

--- a/client_template_copy_disk.go
+++ b/client_template_copy_disk.go
@@ -11,7 +11,7 @@ func (o *oVirtClient) CopyTemplateDiskToStorageDomain(
 	diskID string,
 	storageDomainID string,
 	retries ...RetryStrategy) (result Disk, err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	progress, err := o.StartCopyTemplateDiskToStorageDomain(diskID, storageDomainID, retries...)
 	if err != nil {
 		return nil, err
@@ -24,7 +24,7 @@ func (o *oVirtClient) StartCopyTemplateDiskToStorageDomain(
 	diskID string,
 	storageDomainID string,
 	retries ...RetryStrategy) (DiskUpdate, error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	correlationID := fmt.Sprintf("template_disk_copy_%s", generateRandomID(5, o.nonSecureRandom))
 	sdkStorageDomain := ovirtsdk.NewStorageDomainBuilder().Id(storageDomainID)
 	sdkDisk := ovirtsdk.NewDiskBuilder().Id(diskID)

--- a/client_template_create.go
+++ b/client_template_create.go
@@ -12,7 +12,7 @@ func (o *oVirtClient) CreateTemplate(
 	params OptionalTemplateCreateParameters,
 	retries ...RetryStrategy,
 ) (result Template, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	if params == nil {
 		params = &templateCreateParameters{}
 	}

--- a/client_template_get.go
+++ b/client_template_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetTemplate(id TemplateID, retries ...RetryStrategy) (result Template, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting template %s", id),
 		o.logger,

--- a/client_template_list.go
+++ b/client_template_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListTemplates(retries ...RetryStrategy) (result []Template, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []Template{}
 	err = retry(
 		"listing templates",

--- a/client_template_remove.go
+++ b/client_template_remove.go
@@ -8,7 +8,7 @@ func (o *oVirtClient) RemoveTemplate(
 	templateID TemplateID,
 	retries ...RetryStrategy,
 ) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing template %s", templateID),
 		o.logger,

--- a/client_template_wait_for_status.go
+++ b/client_template_wait_for_status.go
@@ -9,7 +9,7 @@ func (o *oVirtClient) WaitForTemplateStatus(
 	status TemplateStatus,
 	retries ...RetryStrategy,
 ) (result Template, err error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 	err = retry(
 		fmt.Sprintf("waiting for template %s to enter status \"%s\"", id, status),
 		o.logger,

--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 func getHelper(t *testing.T) ovirtclient.TestHelper {

--- a/client_testconnection.go
+++ b/client_testconnection.go
@@ -7,7 +7,7 @@ type TestConnectionClient interface {
 }
 
 func (o *oVirtClient) Test(retries ...RetryStrategy) error {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	return retry(
 		"testing oVirt engine connection",
 		o.logger,
@@ -19,7 +19,7 @@ func (o *oVirtClient) Test(retries ...RetryStrategy) error {
 }
 
 func (m *mockClient) Test(retries ...RetryStrategy) error {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(m))
 	return retry(
 		"testing oVirt engine connection",
 		nil,

--- a/client_vm_create.go
+++ b/client_vm_create.go
@@ -86,7 +86,7 @@ func vmPlacementPolicyParameterConverter(params OptionalVMParameters, builder *o
 }
 
 func (o *oVirtClient) CreateVM(clusterID ClusterID, templateID TemplateID, name string, params OptionalVMParameters, retries ...RetryStrategy) (result VM, err error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 
 	if err := validateVMCreationParameters(clusterID, templateID, name, params); err != nil {
 		return nil, err

--- a/client_vm_get.go
+++ b/client_vm_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetVM(id string, retries ...RetryStrategy) (result VM, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting vm %s", id),
 		o.logger,

--- a/client_vm_list.go
+++ b/client_vm_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListVMs(retries ...RetryStrategy) (result []VM, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []VM{}
 	err = retry(
 		"listing vms",

--- a/client_vm_remove.go
+++ b/client_vm_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveVM(id string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing VM %s", id),
 		o.logger,

--- a/client_vm_search.go
+++ b/client_vm_search.go
@@ -82,7 +82,7 @@ func (o *oVirtClient) vmTagCriteria(params VMSearchParameters, criteria []string
 }
 
 func (o *oVirtClient) SearchVMs(params VMSearchParameters, retries ...RetryStrategy) (result []VM, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []VM{}
 	qs, err := o.vmSearchCriteria(params)
 	if err != nil {

--- a/client_vm_shutdown.go
+++ b/client_vm_shutdown.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) ShutdownVM(id string, force bool, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("shutting down VM %s", id),
 		o.logger,

--- a/client_vm_start.go
+++ b/client_vm_start.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) StartVM(id string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("starting VM %s", id),
 		o.logger,

--- a/client_vm_stop.go
+++ b/client_vm_stop.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) StopVM(id string, force bool, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("stopping VM %s", id),
 		o.logger,

--- a/client_vm_update.go
+++ b/client_vm_update.go
@@ -11,7 +11,7 @@ func (o *oVirtClient) UpdateVM(
 	params UpdateVMParameters,
 	retries ...RetryStrategy,
 ) (result VM, err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 
 	vm := &ovirtsdk.Vm{}
 	vm.SetId(id)

--- a/client_vm_wait_for_status.go
+++ b/client_vm_wait_for_status.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) WaitForVMStatus(id string, status VMStatus, retries ...RetryStrategy) (vm VM, err error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(o))
 	err = retry(
 		fmt.Sprintf("waiting for VM %s status %s", id, status),
 		o.logger,

--- a/client_vnicprofile_create.go
+++ b/client_vnicprofile_create.go
@@ -12,13 +12,13 @@ func (o *oVirtClient) CreateVNICProfile(
 	params OptionalVNICProfileParameters,
 	retries ...RetryStrategy,
 ) (result VNICProfile, err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 
 	if err := validateVNICProfileCreationParameters(name, networkID, params); err != nil {
 		return nil, err
 	}
 
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("creating VNIC profile %s", name),
 		o.logger,

--- a/client_vnicprofile_get.go
+++ b/client_vnicprofile_get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) GetVNICProfile(id string, retries ...RetryStrategy) (result VNICProfile, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting VNIC profile %s", id),
 		o.logger,

--- a/client_vnicprofile_list.go
+++ b/client_vnicprofile_list.go
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListVNICProfiles(retries ...RetryStrategy) (result []VNICProfile, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []VNICProfile{}
 	err = retry(
 		"listing VNIC profiles",

--- a/client_vnicprofile_remove.go
+++ b/client_vnicprofile_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveVNICProfile(id string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing VNIC profile %s", id),
 		o.logger,

--- a/codetemplates/client_ITEM_get.go.tpl
+++ b/codetemplates/client_ITEM_get.go.tpl
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) Get{{ .Object }}(id {{ .IDType }}, retries ...RetryStrategy) (result {{ .Object }}, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting {{ .Name }} %s", id),
 		o.logger,

--- a/codetemplates/client_ITEM_list.go.tpl
+++ b/codetemplates/client_ITEM_list.go.tpl
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) List{{ .Object }}s(retries ...RetryStrategy) (result []{{ .Object }}, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []{{ .Object }}{}
 	err = retry(
 		"listing {{ .Name }}s",

--- a/codetemplates/v2/ITEM_get.go.tpl
+++ b/codetemplates/v2/ITEM_get.go.tpl
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) Get{{ .Object }}(id {{ .IDType }}, retries ...RetryStrategy) (result {{ .Object }}, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting {{ .Name }} %s", id),
 		o.logger,

--- a/codetemplates/v2/ITEM_list.go.tpl
+++ b/codetemplates/v2/ITEM_list.go.tpl
@@ -3,7 +3,7 @@
 package ovirtclient
 
 func (o *oVirtClient) List{{ .Object }}s(retries ...RetryStrategy) (result []{{ .Object }}, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []{{ .Object }}{}
 	err = retry(
 		"listing {{ .Name }}s",

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,58 @@
+package ovirtclient_test
+
+import (
+	"context"
+	"testing"
+
+	ovirtclient "github.com/ovirt/go-ovirt-client"
+)
+
+type ctxKey string
+
+func TestContext(t *testing.T) {
+	helper := getHelper(t)
+
+	cli1 := helper.GetClient()
+
+	ctx := context.WithValue(context.Background(), ctxKey("foo"), "bar")
+
+	cli2 := cli1.WithContext(ctx)
+
+	if err := cli1.Reconnect(); err != nil {
+		t.Fatalf("failed to reconnect (%v)", err)
+	}
+
+	if cli1.GetContext() != nil {
+		t.Fatalf("Context of client 1 is not nil.")
+	}
+	if cli2.GetContext() == nil {
+		t.Fatalf("Context of client 2 is nil.")
+	}
+	if cli2.GetContext().Value(ctxKey("foo")) != "bar" {
+		t.Fatalf("Incorrect context value on client 2.")
+	}
+
+	vm, err := cli1.CreateVM(
+		helper.GetClusterID(),
+		helper.GetBlankTemplateID(),
+		helper.GenerateTestResourceName(t),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Failed to create test VM (%v)", err)
+	}
+	t.Cleanup(
+		func() {
+			if vm != nil {
+				t.Logf("Cleaning up test VM %s...", vm.ID())
+				if err := vm.Remove(); err != nil && !ovirtclient.HasErrorCode(err, ovirtclient.ENotFound) {
+					t.Fatalf("Failed to remove test VM %s (%v)", vm.ID(), err)
+				}
+			}
+		},
+	)
+
+	if _, err := cli2.GetVM(vm.ID()); err != nil {
+		t.Fatalf("Failed to fetch VM from secondary connection (%v)", err)
+	}
+}

--- a/credential_shift_test.go
+++ b/credential_shift_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 func TestCredentialChangeAfterSetup(t *testing.T) {

--- a/example_vm_create_test.go
+++ b/example_vm_create_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 // The following example demonstrates how to create a virtual machine. It is set up

--- a/example_vm_list_test.go
+++ b/example_vm_list_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 // The following example demonstrates how to list virtual machines.

--- a/example_vm_uploadimage_test.go
+++ b/example_vm_uploadimage_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 // This example demonstrates the simplest way to upload an image without special timeout handling. The call still times

--- a/feature.go
+++ b/feature.go
@@ -33,7 +33,7 @@ func (o *oVirtClient) SupportsFeature(feature Feature, retries ...RetryStrategy)
 		return false, newError(EBug, "unknown feature: %s", feature)
 	}
 
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		"fetching engine version",
 		o.logger,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/google/uuid v1.3.0
 	github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c
-	github.com/ovirt/go-ovirt-client-log/v2 v2.2.0
+	github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c h1:jXRFpl7+W0YZj/fg
 github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
 github.com/ovirt/go-ovirt-client-log/v2 v2.2.0 h1:7iZQs+8moX7aopeAdNU1b12mF/yWWBVA/Pey55F9PTQ=
 github.com/ovirt/go-ovirt-client-log/v2 v2.2.0/go.mod h1:mDoU3KIwftpsgZGzXGk5d2UEJYTY0bYMfg/GwPapXL0=
+github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 h1:uvACVHYhYPMkNJrrgWiABcfELB6qoFfsDDUTbpb4Jv4=
+github.com/ovirt/go-ovirt-client-log/v3 v3.0.0/go.mod h1:chKKxCv4lRjxezrTG+EIhkWXGhDAWByglPVXh/iYdnQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/instancetype_get.go
+++ b/instancetype_get.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) GetInstanceType(id InstanceTypeID, retries ...RetryStrategy) (result InstanceType, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting instance type %s", id),
 		o.logger,

--- a/instancetype_list.go
+++ b/instancetype_list.go
@@ -1,7 +1,7 @@
 package ovirtclient
 
 func (o *oVirtClient) ListInstanceTypes(retries ...RetryStrategy) (result []InstanceType, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = []InstanceType{}
 	err = retry(
 		"listing instance types",

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,7 @@
 package ovirtclient
 
 import (
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 // Logger is a thin wrapper around ovirtclientlog.Logger for convenience.

--- a/mock.go
+++ b/mock.go
@@ -1,6 +1,7 @@
 package ovirtclient
 
 import (
+	"context"
 	"math/rand"
 	"net"
 	"sync"
@@ -18,6 +19,7 @@ type MockClient interface {
 }
 
 type mockClient struct {
+	ctx                               context.Context
 	logger                            Logger
 	url                               string
 	lock                              *sync.Mutex
@@ -40,6 +42,42 @@ type mockClient struct {
 	affinityGroups                    map[ClusterID]map[AffinityGroupID]*affinityGroup
 	vmIPs                             map[string]map[string][]net.IP
 	instanceTypes                     map[InstanceTypeID]*instanceType
+}
+
+func (m *mockClient) WithContext(ctx context.Context) Client {
+	return &mockClient{
+		ctx,
+		m.logger.WithContext(ctx),
+		m.url,
+		m.lock,
+		m.nonSecureRandom,
+		m.vms,
+		m.storageDomains,
+		m.disks,
+		m.clusters,
+		m.hosts,
+		m.templates,
+		m.nics,
+		m.vnicProfiles,
+		m.networks,
+		m.dataCenters,
+		m.vmDiskAttachmentsByVM,
+		m.vmDiskAttachmentsByDisk,
+		m.templateDiskAttachmentsByTemplate,
+		m.templateDiskAttachmentsByDisk,
+		m.tags,
+		m.affinityGroups,
+		m.vmIPs,
+		m.instanceTypes,
+	}
+}
+
+func (m *mockClient) GetContext() context.Context {
+	return m.ctx
+}
+
+func (m *mockClient) Reconnect() (err error) {
+	return nil
 }
 
 func (m *mockClient) GetURL() string {

--- a/mock_template_remove.go
+++ b/mock_template_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (m *mockClient) RemoveTemplate(id TemplateID, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(m))
 	err = retry(
 		fmt.Sprintf("removing template %s", id),
 		m.logger,

--- a/mock_template_wait_for_status.go
+++ b/mock_template_wait_for_status.go
@@ -9,7 +9,7 @@ func (m *mockClient) WaitForTemplateStatus(
 	status TemplateStatus,
 	retries ...RetryStrategy,
 ) (result Template, err error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(m))
 	err = retry(
 		fmt.Sprintf("waiting for template %s to enter status \"%s\"", id, status),
 		nil,

--- a/mock_vm_create.go
+++ b/mock_vm_create.go
@@ -15,7 +15,7 @@ func (m *mockClient) CreateVM(
 	params OptionalVMParameters,
 	retries ...RetryStrategy,
 ) (result VM, err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(m))
 
 	if err := validateVMCreationParameters(clusterID, templateID, name, params); err != nil {
 		return nil, err

--- a/mock_vm_remove.go
+++ b/mock_vm_remove.go
@@ -4,7 +4,7 @@ import "fmt"
 
 func (m *mockClient) RemoveVM(id string, retries ...RetryStrategy) error {
 
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(m))
 
 	return retry(
 		fmt.Sprintf("removing VM %s", id),

--- a/mock_vm_wait_for_status.go
+++ b/mock_vm_wait_for_status.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (m *mockClient) WaitForVMStatus(id string, status VMStatus, retries ...RetryStrategy) (vm VM, err error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(m))
 	err = retry(
 		fmt.Sprintf("waiting for VM %s status %s", id, status),
 		m.logger,

--- a/new_test.go
+++ b/new_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 func TestBadOVirtURL(t *testing.T) {

--- a/newmock.go
+++ b/newmock.go
@@ -77,6 +77,7 @@ func getClient(
 	testDatacenter *datacenterWithClusters,
 ) *mockClient {
 	client := &mockClient{
+		ctx:             nil,
 		logger:          logger,
 		url:             "https://localhost/ovirt-engine/api",
 		lock:            &sync.Mutex{},

--- a/template_disk_list.go
+++ b/template_disk_list.go
@@ -8,7 +8,7 @@ func (o *oVirtClient) ListTemplateDiskAttachments(
 	templateID TemplateID,
 	retries ...RetryStrategy,
 ) (result []TemplateDiskAttachment, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("listing disk attachments for template %s", templateID),
 		o.logger,

--- a/template_get_by_name.go
+++ b/template_get_by_name.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) GetTemplateByName(templateName string, retries ...RetryStrategy) (result Template, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting template by Name %s", templateName),
 		o.logger,

--- a/test_helper.go
+++ b/test_helper.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v2"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
 // TestHelper is a helper to run tests against an oVirt engine. When created it scans the oVirt Engine and tries to find

--- a/vm_get_by_name.go
+++ b/vm_get_by_name.go
@@ -6,7 +6,7 @@ import (
 
 func (o *oVirtClient) GetVMByName(name string, retries ...RetryStrategy) (result VM, err error) {
 
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("getting vm name %s", name),
 		o.logger,

--- a/vm_ip_get.go
+++ b/vm_ip_get.go
@@ -22,7 +22,7 @@ func (m *mockClient) GetVMIPAddresses(id string, params VMIPSearchParams, _ ...R
 }
 
 func (o *oVirtClient) GetVMIPAddresses(id string, params VMIPSearchParams, retries ...RetryStrategy) (result map[string][]net.IP, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	result = map[string][]net.IP{}
 	err = retry(
 		fmt.Sprintf("getting IP addresses for VM %s", id),

--- a/vm_ip_wait.go
+++ b/vm_ip_wait.go
@@ -18,9 +18,9 @@ func waitForIPAddresses(
 	params VMIPSearchParams,
 	retries []RetryStrategy,
 	logger Logger,
-	client VMClient,
+	client Client,
 ) (result map[string][]net.IP, err error) {
-	retries = defaultRetries(retries, defaultLongTimeouts())
+	retries = defaultRetries(retries, defaultLongTimeouts(client))
 	err = retry(
 		fmt.Sprintf("waiting for IP addresses on VM %s", id),
 		logger,

--- a/vm_tag_add.go
+++ b/vm_tag_add.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (o *oVirtClient) AddTagToVM(id string, tagID string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("adding tag %s to VM %s", tagID, id),
 		o.logger,
@@ -42,7 +42,7 @@ func (m *mockClient) AddTagToVM(id string, tagID string, retries ...RetryStrateg
 }
 
 func (o *oVirtClient) AddTagToVMByName(id string, tagName string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("adding tag %s to VM %s", tagName, id),
 		o.logger,

--- a/vm_tag_list.go
+++ b/vm_tag_list.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) ListVMTags(id string, retries ...RetryStrategy) (result []Tag, err error) {
-	retries = defaultRetries(retries, defaultReadTimeouts())
+	retries = defaultRetries(retries, defaultReadTimeouts(o))
 	err = retry(
 		fmt.Sprintf("listing tags for vm %s", id),
 		o.logger,

--- a/vm_tag_remove.go
+++ b/vm_tag_remove.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (o *oVirtClient) RemoveTagFromVM(id string, tagID string, retries ...RetryStrategy) (err error) {
-	retries = defaultRetries(retries, defaultWriteTimeouts())
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	err = retry(
 		fmt.Sprintf("removing tag from VM %s", id),
 		o.logger,


### PR DESCRIPTION
## Please describe the change you are making

This PR adds code to automatically reconnect in case an invalid_grant error is encountered. This fixes #151.

This is, as of yet, untested as we don't have a good way to trigger an invalid_grant event.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
