### PR TITLE
Remove setting up Go tooling before golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-      - name: Run go generate
-        run: go generate
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
   test:


### PR DESCRIPTION
## Please describe the change you are making

Removing setting up go tooling before running the golangci-lint action because it leads to a bug. This tooling is no longer needed anyway because we no longer need to run `go generate` before linting.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
