### PR TITLE
Fixes #180: Getting VM by name doesn't return an error if no VM is found

### DIFF
--- a/vm_get_by_name.go
+++ b/vm_get_by_name.go
@@ -18,21 +18,14 @@ func (o *oVirtClient) GetVMByName(name string, retries ...RetryStrategy) (result
 			}
 			for _, sdkObject := range response.MustVms().Slice() {
 				if mName, ok := sdkObject.Name(); ok {
+					// We re-scan for the name here since the search function may result other VMs too.
 					if name == mName {
 						result, err = convertSDKVM(sdkObject, o)
-						if err != nil {
-							return wrap(
-								err,
-								EBug,
-								"failed to convert vm %s",
-								name,
-							)
-						}
-
+						return err
 					}
 				}
 			}
-			return nil
+			return newError(ENotFound, "No VM found with name %s", name)
 		})
 	return result, err
 }
@@ -45,5 +38,5 @@ func (m *mockClient) GetVMByName(name string, _ ...RetryStrategy) (result VM, er
 			return vm, nil
 		}
 	}
-	return nil, newError(ENotFound, "vm with Name %s not found", name)
+	return nil, newError(ENotFound, "No VM found with name %s", name)
 }


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes #180 and returns an error if no VM is found.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
