### PR TITLE
Fix 183 add ProxyFromEnvironment

### DIFF
--- a/new.go
+++ b/new.go
@@ -137,6 +137,7 @@ func NewWithVerify(
 
 	httpClient := http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}


### PR DESCRIPTION
I haven't tested this, the issue explains the testing env needs a proxy which is either there (to test the fix) or not there (to verify the fix).

## Please describe the change you are making
Fix for Issue 183, add the ProxyFromEnvironment to the http.Client initialize.
...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Not owner. Will sign commit agreement.
.
## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes.
...
