### PR TITLE
Fixes #183: Adding support for proxies

### DIFF
--- a/credential_shift_test.go
+++ b/credential_shift_test.go
@@ -27,7 +27,7 @@ func TestCredentialChangeAfterSetup(t *testing.T) {
 		t.Fatalf("failed to create server certificate (%v)", err)
 	}
 
-	port := getNextFreePort()
+	port := getNextFreePort(t)
 
 	srv, err := newTestServer(port, serverCert, serverPrivKey, &unauthorizedHandler{})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db
+	github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c
 	github.com/ovirt/go-ovirt-client-log/v2 v2.2.0
 	github.com/stretchr/testify v1.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db h1:ahvAlEurj4TF1SExDJHNeqknQC8lAwnZEPLyZJuRyd0=
-github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
+github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c h1:jXRFpl7+W0YZj/fghoYuE4vJWW/KeQGvdrhnRwRGtAY=
+github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
 github.com/ovirt/go-ovirt-client-log/v2 v2.2.0 h1:7iZQs+8moX7aopeAdNU1b12mF/yWWBVA/Pey55F9PTQ=
 github.com/ovirt/go-ovirt-client-log/v2 v2.2.0/go.mod h1:mDoU3KIwftpsgZGzXGk5d2UEJYTY0bYMfg/GwPapXL0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -15,8 +13,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/zchee/go-qcow2 v0.0.0-20170102190316-9a991fd172f0 h1:dyzM+LWIb64QGUsDUZ2y6e2NkkqejOv8PEv05ajx1co=
-github.com/zchee/go-qcow2 v0.0.0-20170102190316-9a991fd172f0/go.mod h1:XO8ymgJzGFNntEd5L8yc0l1wyz3T5DbQD4lguyldfMA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/new_test.go
+++ b/new_test.go
@@ -1,10 +1,15 @@
 package ovirtclient_test
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client"
@@ -119,7 +124,7 @@ func TestBadTLS(t *testing.T) {
 		t.Fatalf("failed to create server certificate (%v)", err)
 	}
 
-	port := getNextFreePort()
+	port := getNextFreePort(t)
 
 	srv, err := newTestServer(port, serverCert, serverPrivKey, &noopHandler{})
 	if err != nil {
@@ -152,4 +157,150 @@ func TestBadTLS(t *testing.T) {
 	} else {
 		t.Fatalf("the returned error was not an EngineError (%v)", err)
 	}
+}
+
+func TestProxy(t *testing.T) {
+	counter := 0
+	proxy := startProxyServer(t, &counter)
+	t.Parallel()
+	// Real CA is the CA we will use in the server
+	realCAPrivKey, realCACert, realCABytes, err := createCA()
+	if err != nil {
+		t.Fatalf("failed to create real CA (%v)", err)
+	}
+
+	serverPrivKey, serverCert, err := createSignedCert(
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		realCAPrivKey,
+		realCACert,
+	)
+	if err != nil {
+		t.Fatalf("failed to create server certificate (%v)", err)
+	}
+
+	port := getNextFreePort(t)
+
+	srv, err := newTestServer(port, serverCert, serverPrivKey, &unauthorizedHandler{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Stop)
+
+	logger := ovirtclientlog.NewTestLogger(t)
+	_, err = ovirtclient.New(
+		fmt.Sprintf("https://127.0.0.1:%d", port),
+		"admin@internal",
+		"asdf",
+		ovirtclient.TLS().CACertsFromMemory(realCABytes),
+		logger,
+		ovirtclient.NewExtraSettings().WithProxy(fmt.Sprintf("http://%s", proxy)),
+	)
+	if err == nil {
+		t.Fatalf("No error on establishing a connection (%v)", err)
+	}
+	if !ovirtclient.HasErrorCode(err, ovirtclient.EAccessDenied) {
+		t.Fatalf("incorrect error code returned: %v", err)
+	}
+	if counter == 0 {
+		t.Fatalf("Connection did not go through the proxy.")
+	}
+}
+
+func startProxyServer(t *testing.T, counter *int) string {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to open listen socket for the proxy (%v)", err)
+	}
+	var serverError error
+	srv := http.Server{
+		Addr: ln.Addr().String(),
+		// Disable HTTP/2.
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+	}
+	srv.Handler = &proxyHandler{counter: counter}
+	go func() {
+		defer wg.Done()
+		if err := srv.Serve(ln); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				serverError = err
+			}
+		}
+	}()
+	t.Cleanup(
+		func() {
+			if err := srv.Close(); err != nil {
+				t.Fatalf("failed to close listen socket (%v)", err)
+			}
+			wg.Wait()
+			if serverError != nil {
+				t.Fatalf("proxy server stopped unexpectedly (%v)", err)
+			}
+		})
+	return ln.Addr().String()
+}
+
+type proxyHandler struct {
+	counter *int
+}
+
+func (p *proxyHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	*p.counter++
+	if request.Method != "CONNECT" {
+		writer.WriteHeader(400)
+		return
+	}
+	target := request.URL.Host
+
+	hijacker, ok := writer.(http.Hijacker)
+	if !ok {
+		writer.WriteHeader(500)
+		return
+	}
+
+	backendConn, err := net.Dial("tcp", target)
+	if err != nil {
+		writer.WriteHeader(500)
+		return
+	}
+
+	writer.WriteHeader(200)
+	conn, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	if clientBuf != nil {
+		bytes := clientBuf.Reader.Buffered()
+		buf := make([]byte, bytes)
+		n, err := clientBuf.Read(buf)
+		if err != nil {
+			return
+		}
+		if n < bytes {
+			// This is a bug
+			return
+		}
+		if len(buf) > 0 {
+			_, _ = backendConn.Write(buf)
+		}
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(backendConn, conn)
+		_ = backendConn.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(conn, backendConn)
+		_ = conn.Close()
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes #183 and adds support for proxy servers in front of the oVirt engine. This change depends on oVirt/ovirt-engine-sdk-go#239.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
