### PR TITLE
added nolint to pass new golangci-lint v1.46.0

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -2323,6 +2323,7 @@ type VMStatusList []VMStatus
 // Copy creates a separate copy of the current status list.
 func (l VMStatusList) Copy() VMStatusList {
 	result := make([]VMStatus, len(l))
+	// nolint:gosimple
 	for i, s := range l {
 		result[i] = s
 	}


### PR DESCRIPTION
## Please describe the change you are making

The changes in this PR lets the linter pass for the new [golangci-lint v1.46.0](https://github.com/golangci/golangci-lint/releases/tag/v1.46.0)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
