### PR TITLE
Fixed comments about the certificate pool not being available on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ func main() {
 		regexp.MustCompile(`\.pem`),
 	)
 
-	// Add system certificates. This doesn't work on Windows.
+	// Add system certificates. This doesn't work on Windows before Go 1.18.
 	tls.CACertsFromSystem()
 
 	// Add a custom cert pool as a source of certificates. This option is

--- a/doc.go
+++ b/doc.go
@@ -23,7 +23,7 @@ There are several ways to create a client instance. The most basic way is to use
         // Password
         "super-secret",
         // Pull CA certificates from the operating system.
-        // This won't work on Windows. See below for an extended example.
+        // This won't work on Windows before Go 1.18. See below for an extended example.
         ovirtclient.TLS().CACertsFromSystem(),
         // Don't log.
         ovirtclientlog.NewNOOPLogger(),

--- a/scripts/get_test_image/get_test_image.go
+++ b/scripts/get_test_image/get_test_image.go
@@ -38,7 +38,7 @@ var testImageDownloadHTTPClient = &http.Client{
 func getTestImageDownloadCertPool() *x509.CertPool {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		// This will happen on Windows where system pools are not supported.
+		// This will happen on Windows where system pools are not supported before Go 1.18.
 		certPool = x509.NewCertPool()
 		certPool.AppendCertsFromPEM(gitHubCerts)
 	}

--- a/tls.go
+++ b/tls.go
@@ -276,7 +276,7 @@ func (s *standardTLSProvider) createCertPool() (*x509.CertPool, error) {
 
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		// This is the case on Windows where the system certificate pool is not available.
+		// This is the case on Windows before go 1.18 where the system certificate pool is not available.
 		// See https://github.com/golang/go/issues/16736
 		return nil, wrap(err, ETLSError, "system cert pool not available")
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -22,7 +22,7 @@ func ExampleTLS() {
 	// names.
 	tls.CACertsFromDir("/path/to/certs", regexp.MustCompile(`\.pem`))
 
-	// Add system certificates. This does not work on Windows.
+	// Add system certificates. This does not work on Windows before Go 1.18.
 	tls.CACertsFromSystem()
 
 	// Disable certificate verification. This is a bad idea.


### PR DESCRIPTION
## Please describe the change you are making

This change fixes the comments to indicate that golang/go#46287 has now been fixed and certificate pools are available in Go 1.18 and up.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
