### PR TITLE
Added missing default retry values for optimizing VM CPU settings

### DIFF
--- a/vm_optimize_pinning.go
+++ b/vm_optimize_pinning.go
@@ -3,6 +3,7 @@ package ovirtclient
 import "fmt"
 
 func (o *oVirtClient) AutoOptimizeVMCPUPinningSettings(id VMID, optimize bool, retries ...RetryStrategy) error {
+	retries = defaultRetries(retries, defaultWriteTimeouts(o))
 	return retry(
 		fmt.Sprintf("optimizing CPU pinning settings for VM %s", id),
 		o.logger,


### PR DESCRIPTION
## Please describe the change you are making

This PR adds the missing default retry values for optimizing the VM CPU pinning settings.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
