### PR TITLE
added disk size validation for update disk params

### DIFF
--- a/const.go
+++ b/const.go
@@ -3,3 +3,7 @@ package ovirtclient
 // DefaultBlankTemplateID returns the ID for the factory-default blank template. This should not be used
 // as the template may be deleted from the oVirt engine. Instead, use the API call to find the blank template.
 const DefaultBlankTemplateID TemplateID = "00000000-0000-0000-0000-000000000000"
+
+// MinDiskSizeOVirt defines the minimum size of 1M for disks in oVirt. Smaller disks can be created, but they
+// lead to bugs in oVirt when creating disks from templates and changing the format.
+const MinDiskSizeOVirt uint64 = 1048576

--- a/disk.go
+++ b/disk.go
@@ -315,6 +315,11 @@ func (u *updateDiskParams) ProvisionedSize() *uint64 {
 }
 
 func (u *updateDiskParams) WithProvisionedSize(size uint64) (BuildableUpdateDiskParameters, error) {
+	err := validateDiskSize(size)
+	if err != nil {
+		return u, err
+	}
+
 	u.provisionedSize = &size
 	return u, nil
 }

--- a/disk_create.go
+++ b/disk_create.go
@@ -67,10 +67,12 @@ func validateDiskCreationParameters(format ImageFormat, size uint64) error {
 	if err := format.Validate(); err != nil {
 		return err
 	}
-	if size < 1048576 {
-		// 1M is the minimum size for disks in oVirt. Smaller disks can be created, but they lead to bugs in oVirt
-		// when creating disks from templates and changing the format.
-		return newError(EBadArgument, "Disk size must be at least 1048576 bytes (1 MB)")
+	return validateDiskSize(size)
+}
+
+func validateDiskSize(size uint64) error {
+	if size < MinDiskSizeOVirt {
+		return newError(EBadArgument, "Disk size must be at least %d bytes (1 MB)", MinDiskSizeOVirt)
 	}
 	return nil
 }


### PR DESCRIPTION
## Please describe the change you are making

Currently, only during disk creation the size is validated [see here](https://github.com/oVirt/go-ovirt-client/blob/main/disk_create.go#L66-L76). 

This PR adds 
- a validation check for updating the disk
- and introduces the min. disk size for oVirt as exported constant

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
