### PR TITLE
use default blank template ID const when vm clone is true

### DIFF
--- a/vm_create.go
+++ b/vm_create.go
@@ -349,7 +349,7 @@ func (m *mockClient) CreateVM(
 			m.attachVMDisksFromTemplate(tpl, vm, params)
 
 			if clone := params.Clone(); clone != nil && *clone {
-				vm.templateID = "00000000-0000-0000-0000-000000000000"
+				vm.templateID = DefaultBlankTemplateID
 			}
 
 			m.vmIPs[vm.id] = map[string][]net.IP{}

--- a/vm_test.go
+++ b/vm_test.go
@@ -288,7 +288,7 @@ func TestCanRemoveTemplateIfVMIsCloned(t *testing.T) {
 		template.ID(),
 		ovirtclient.CreateVMParams().MustWithClone(true),
 	)
-	if vm.TemplateID() != "00000000-0000-0000-0000-000000000000" {
+	if vm.TemplateID() != ovirtclient.DefaultBlankTemplateID {
 		t.Fatalf("Template ID is not set correctly on cloned VM (%s vs %s)", vm.TemplateID(), template.ID())
 	}
 	assertCanRemoveTemplate(t, helper, template.ID())


### PR DESCRIPTION
## Please describe the change you are making

In this PR the defined constant `DefaultBlankTemplateID` is being used instead of an inline defined constant when creating a VM and clone is true. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
