### PR TITLE
Fixes crash when no affinity groups are present with a given name

### DIFF
--- a/affinitygroup_get_by_name.go
+++ b/affinitygroup_get_by_name.go
@@ -36,8 +36,11 @@ func (o *oVirtClient) GetAffinityGroupByName(clusterID ClusterID, name string, r
 					results = append(results, item)
 				}
 			}
+			if len(results) == 0 {
+				return newError(ENotFound, "no affinity group named %s found in cluster %s", name, clusterID)
+			}
 			if len(results) > 1 {
-				return newError(EMultipleResults, "no affinity group named %s found in cluster %s", name, clusterID)
+				return newError(EMultipleResults, "multiple affinity groups with the name %s found in cluster %s", name, clusterID)
 			}
 			result, err = convertSDKAffinityGroup(results[0], o)
 			if err != nil {


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes a bug discovered by @eslutsky:

```
DEBUG panic: runtime error: index out of range [0] with length 0 
DEBUG                                              
DEBUG goroutine 59 [running]:                      
DEBUG github.com/ovirt/go-ovirt-client.(*oVirtClient).GetAffinityGroupByName.func1() 
DEBUG     /root/installer/terraform/providers/ovirt/vendor/github.com/ovirt/go-ovirt-client/affinitygroup_get_by_name.go:42 +0x6a5 
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
