### PR TITLE
Detect locked VM and issue proper error code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -71,6 +71,9 @@ const EUnsupported ErrorCode = "unsupported"
 // EDiskLocked indicates that the disk in question is locked.
 const EDiskLocked ErrorCode = "disk_locked"
 
+// EVMLocked indicates that the virtual machine in question is locked.
+const EVMLocked ErrorCode = "vm_locked"
+
 // ERelatedOperationInProgress means that the engine is busy working on something else on the same resource.
 const ERelatedOperationInProgress ErrorCode = "related_operation_in_progress"
 
@@ -302,6 +305,8 @@ func realIdentify(err error) EngineError {
 		return wrap(err, ENotFound, "the requested resource was not found")
 	case strings.Contains(err.Error(), "Disk is locked"):
 		return wrap(err, EDiskLocked, "the disk is locked")
+	case strings.Contains(err.Error(), "VM is locked"):
+		return wrap(err, EVMLocked, "the VM is locked")
 	case strings.Contains(err.Error(), "Failed to hot-plug disk"):
 		return wrap(err, EHotPlugFailed, "failed to hot-plug disk")
 	case strings.Contains(err.Error(), "Related operation is currently in progress."):

--- a/retry.go
+++ b/retry.go
@@ -115,7 +115,7 @@ func logRetry(action string, logger ovirtclientlog.Logger, err error) {
 	isConflict := false
 	if errors.As(err, &e) {
 		isPending = e.HasCode(EPending)
-		isConflict = e.HasCode(EConflict)
+		isConflict = e.HasCode(EConflict) || e.HasCode(EDiskLocked) || e.HasCode(EVMLocked)
 	}
 	if isPending || isConflict {
 		logger.Debugf("Still %s, retrying... (%s)", action, err.Error())


### PR DESCRIPTION
## Please describe the change you are making

This change detects the following error and converts it into a nicer error message:

```
Cannot run VM: VM is locked. Please try again in a few minutes.
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
