### PR TITLE
Fixed error message when reaching maximum retries

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -389,7 +389,7 @@ func (m *maxTriesStrategy) Continue(err error, action string) error {
 		return wrap(
 			err,
 			ETimeout,
-			"maximum retries reached while trying to %s, giving up",
+			"maximum retries reached while %s, giving up",
 			action,
 		)
 	}


### PR DESCRIPTION
## Please describe the change you are making

This PR replaces this:

```
maximum retries reached while trying to waiting for VM
```

With this:

```
maximum retries reached while waiting for VM
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
