### PR TITLE
Fix tests failing due to disks not bootable

### DIFF
--- a/disk_remove_test.go
+++ b/disk_remove_test.go
@@ -24,7 +24,7 @@ func TestDiskRemoveFromRunningVMShouldResultInError(t *testing.T) {
 	helper := getHelper(t)
 	disk := assertCanCreateDisk(t, helper)
 	vm := assertCanCreateVM(t, helper, fmt.Sprintf("test-%s", helper.GenerateRandomID(5)), nil)
-	assertCanAttachDisk(t, vm, disk)
+	assertCanAttachDiskWithParams(t, vm, disk, ovirtclient.CreateDiskAttachmentParams().MustWithBootable(true).MustWithActive(true))
 	assertCanStartVM(t, helper, vm)
 	if err := disk.Remove(ovirtclient.MaxTries(5)); err == nil {
 		t.Fatalf("Removing a disk from a running VM did not result in an error.")

--- a/vm_test.go
+++ b/vm_test.go
@@ -243,7 +243,7 @@ func TestVMStartStop(t *testing.T) {
 		nil,
 	)
 	disk := assertCanCreateDisk(t, helper)
-	assertCanAttachDisk(t, vm, disk)
+	assertCanAttachDiskWithParams(t, vm, disk, ovirtclient.CreateDiskAttachmentParams().MustWithBootable(true).MustWithActive(true))
 	assertCanUploadDiskImage(t, helper, disk)
 	assertCanStartVM(t, helper, vm)
 	assertVMWillStart(t, vm)
@@ -923,6 +923,6 @@ func assertCanCreateBootableVM(t *testing.T, helper ovirtclient.TestHelper) ovir
 	)
 	disk1 := assertCanCreateDisk(t, helper)
 	assertCanUploadDiskImage(t, helper, disk1)
-	assertCanAttachDisk(t, vm1, disk1)
+	assertCanAttachDiskWithParams(t, vm1, disk1, ovirtclient.CreateDiskAttachmentParams().MustWithBootable(true).MustWithActive(true))
 	return vm1
 }


### PR DESCRIPTION
## Please describe the change you are making

Following tests were failing on live backend due to VMs not being able to start
because the disks created during the execution were not bootable and were
not activated:

TestNegativeVMAffinityShouldResultInDifferenHosts
TestDiskRemoveFromRunningVMShouldResultInError
TestVMStartStop

This PR aims to fix that. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
