### PR TITLE
OCPRHV-794: added soundcard enabled flag to builder and VM

### DIFF
--- a/new_test.go
+++ b/new_test.go
@@ -278,6 +278,7 @@ func startProxyServer(t *testing.T, counter *int) string {
 		t.Fatalf("failed to open listen socket for the proxy (%v)", err)
 	}
 	var serverError error
+	//nolint:gosec
 	srv := http.Server{
 		Addr: ln.Addr().String(),
 		// Disable HTTP/2.

--- a/util_test.go
+++ b/util_test.go
@@ -146,6 +146,7 @@ func newTestServer(t *testing.T, port int, serverCert []byte, serverPrivKey []by
 	if err != nil {
 		return nil, fmt.Errorf("failed to create key pair (%w)", err)
 	}
+	//nolint:gosec
 	srv := &http.Server{
 		Addr:     fmt.Sprintf("127.0.0.1:%d", port),
 		Handler:  handler,

--- a/vm_create.go
+++ b/vm_create.go
@@ -158,6 +158,7 @@ func createSDKVM(
 		vmTypeCreator,
 		vmOSCreator,
 		vmSerialConsoleCreator,
+		vmSoundcardEnabledCreator,
 	}
 
 	for _, part := range parts {
@@ -202,6 +203,14 @@ func vmSerialConsoleCreator(params OptionalVMParameters, builder *ovirtsdk.VmBui
 		return
 	}
 	builder.ConsoleBuilder(ovirtsdk.NewConsoleBuilder().Enabled(*serial))
+}
+
+func vmSoundcardEnabledCreator(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) {
+	soundcardEnabled := params.SoundcardEnabled()
+	if soundcardEnabled == nil {
+		return
+	}
+	builder.SoundcardEnabled(*soundcardEnabled)
 }
 
 func vmOSCreator(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) {
@@ -397,6 +406,11 @@ func (m *mockClient) createVM(
 		console = *serialConsole
 	}
 
+	soundcardEnabled := true
+	if isEnabled := params.SoundcardEnabled(); isEnabled != nil {
+		soundcardEnabled = *isEnabled
+	}
+
 	vm := &vm{
 		m,
 		VMID(id),
@@ -417,6 +431,7 @@ func (m *mockClient) createVM(
 		vmType,
 		m.createVMOS(params),
 		console,
+		soundcardEnabled,
 	}
 	m.vms[VMID(id)] = vm
 	return vm


### PR DESCRIPTION
## Please describe the change you are making

This PR adds the `SoundcardEnabled` flag to the VM as well as the Builder. This is necessary for 
- https://issues.redhat.com/browse/OCPRHV-794
- https://issues.redhat.com/browse/OCPRHV-785

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
