### PR TITLE
added AllContent flag when getting VMs

### DIFF
--- a/vm_get.go
+++ b/vm_get.go
@@ -11,7 +11,7 @@ func (o *oVirtClient) GetVM(id VMID, retries ...RetryStrategy) (result VM, err e
 		o.logger,
 		retries,
 		func() error {
-			response, err := o.conn.SystemService().VmsService().VmService(string(id)).Get().Send()
+			response, err := o.conn.SystemService().VmsService().VmService(string(id)).Get().AllContent(true).Send()
 			if err != nil {
 				return err
 			}

--- a/vm_list.go
+++ b/vm_list.go
@@ -8,7 +8,7 @@ func (o *oVirtClient) ListVMs(retries ...RetryStrategy) (result []VM, err error)
 		o.logger,
 		retries,
 		func() error {
-			response, e := o.conn.SystemService().VmsService().List().Send()
+			response, e := o.conn.SystemService().VmsService().List().AllContent(true).Send()
 			if e != nil {
 				return e
 			}

--- a/vm_test.go
+++ b/vm_test.go
@@ -795,11 +795,12 @@ func TestVMSerialConsole(t *testing.T) {
 				)
 				if vm.SerialConsole() != tc.expected {
 					t.Fatalf(
-						"Incorrect value for serial console (expected: %t, got: %t)",
+						"Incorrect value for serial console when creating (expected: %t, got: %t)",
 						tc.expected,
 						vm.SerialConsole(),
 					)
 				}
+
 				t.Logf("Found correct value for serial console: %t", tc.expected)
 			},
 		)
@@ -845,6 +846,20 @@ func TestVMSoundcardEnabled(t *testing.T) {
 				if vm.SoundcardEnabled() != tc.expected {
 					t.Fatalf(
 						"Incorrect value for soundcard (expected: %t, got: %t)",
+						tc.expected,
+						vm.SoundcardEnabled(),
+					)
+				}
+
+				// retrieve VM one more time to ensure that the sound_card attribute is set as it is excluded by default
+				// https://ovirt-engine.ocp-on-ovirt.gcp.devcluster.openshift.com/ovirt-engine/apidoc/#services/vm/methods/get/parameters/all_content
+				sameVM, err := helper.GetClient().GetVM(vm.ID())
+				if err != nil {
+					t.Fatalf("Failed to retrieve created VM: %v", err)
+				}
+				if sameVM.SoundcardEnabled() != tc.expected {
+					t.Fatalf(
+						"Incorrect value for serial console when retrieving (expected: %t, got: %t)",
 						tc.expected,
 						vm.SoundcardEnabled(),
 					)


### PR DESCRIPTION
## Please describe the change you are making

This PR adds `all_content=true` to the `GET /vms` requests. Fields such as `soundcard_enabled` are excluded by default (see [api documentation](https://ovirt-engine.ocp-on-ovirt.gcp.devcluster.openshift.com/ovirt-engine/apidoc/#services/vm/methods/get/parameters/all_content)). Therefore, setting all_content will allow the client to fetch this information as well. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
