### PR TITLE
use default value for soundcard_enabled

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -2170,9 +2170,11 @@ func vmSerialConsoleConverter(object *ovirtsdk.Vm, v *vm, logger Logger, action 
 }
 
 func vmSoundcardEnabledConverter(object *ovirtsdk.Vm, v *vm) error {
+	// soundcard_enabled is excluded from the response from oVirt engine by default. Therefore, using the default bool value as return value
+	// see: http://ovirt.github.io/ovirt-engine-api-model/master/#services/disk/methods/get/parameters/all_content
 	soundcardEnabled, ok := object.SoundcardEnabled()
 	if !ok {
-		return newFieldNotFound("vm", "soundcard enabled")
+		v.soundcardEnabled = false
 	}
 	v.soundcardEnabled = soundcardEnabled
 	return nil


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes the soundcard enabled field. Since `soundcard_enabled` is excluded by ovirt-engine, the field is set to the default bool value to prevent failing requests. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
