### PR TITLE
fixed panic on failed update disk

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     # region Code Quality and Comments
 
     # Inspect source code for potential security problems. This check has a fairly high false positive rate,
-    # comment with // nolint:gosec where not relevant.
+    # comment with //nolint:gosec where not relevant.
     - gosec
     # Replace golint.
     - revive
@@ -45,15 +45,15 @@ linters:
     - unparam
     # Check for non-ASCII identifiers.
     - asciicheck
-    # Check for HTTP response body being closed. Sometimes, you may need to disable this using // nolint:bodyclose.
+    # Check for HTTP response body being closed. Sometimes, you may need to disable this using //nolint:bodyclose.
     - bodyclose
-    # Check for duplicate code. You may want to disable this with // nolint:dupl if the source code is the same, but
+    # Check for duplicate code. You may want to disable this with //nolint:dupl if the source code is the same, but
     # legitimately exists for different reasons.
     - dupl
     # Check for pointers in loops. This is a typical bug source.
     - exportloopref
     # Enforce a reasonable function length of 60 lines or 40 instructions. In very rare cases you may want to disable
-    # this with // nolint:funlen if there is absolutely no way to split the function in question.
+    # this with //nolint:funlen if there is absolutely no way to split the function in question.
     - funlen
     # Prevent dogsledding (mass-ignoring return values). This typically indicates missing error handling.
     - dogsled
@@ -97,3 +97,10 @@ linters-settings:
       - all
 issues:
   exclude-use-default: false
+  exclude-rules:
+    - linters:
+        - gofmt
+      source: "//"
+    - linters:
+        - gofmt
+      source: "/*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The provided [.golangci.yaml](.golangci.yml) describes the linting rules we are 
 // We are working through all template files here, so
 // including these files is intentional and not a
 // security issue.
-fh, err := os.Open(templateFileName) // nolint:gosec
+fh, err := os.Open(templateFileName) //nolint:gosec
 ```
 
 ## Design principles

--- a/affinitygroup_list.go
+++ b/affinitygroup_list.go
@@ -2,7 +2,7 @@ package ovirtclient
 
 import "fmt"
 
-// nolint:dupl
+//nolint:dupl
 func (o *oVirtClient) ListAffinityGroups(
 	clusterID ClusterID,
 	retries ...RetryStrategy,

--- a/disk_attachment_list.go
+++ b/disk_attachment_list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// nolint:dupl
+//nolint:dupl
 func (o *oVirtClient) ListDiskAttachments(
 	vmid VMID,
 	retries ...RetryStrategy,

--- a/disk_downloadimage_test.go
+++ b/disk_downloadimage_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	ovirtclient "github.com/ovirt/go-ovirt-client/v2"
@@ -90,7 +89,7 @@ func getFullTestImage(t *testing.T) (io.ReadSeekCloser, uint64, uint64) {
 	}
 	size := stat.Size()
 
-	fullTestImage, err := ioutil.ReadAll(fh)
+	fullTestImage, err := io.ReadAll(fh)
 	if err != nil {
 		t.Skipf("testimage/full.qcow not found in the test environment. Did you run go generate? (%v)", err)
 	}
@@ -130,7 +129,7 @@ func getTestImageData(t *testing.T) ([]byte, uint64) {
 	}
 	size := stat.Size()
 
-	testImage, err := ioutil.ReadAll(fh)
+	testImage, err := io.ReadAll(fh)
 	if err != nil {
 		t.Errorf("testimage/image not found in the test environment. (%v)", err)
 	}
@@ -150,7 +149,7 @@ func downloadImage(
 		_ = imageDownload.Close()
 	}()
 
-	data, err := ioutil.ReadAll(imageDownload)
+	data, err := io.ReadAll(imageDownload)
 	if err != nil {
 		t.Fatal(fmt.Errorf("failed to download image (%w)", err))
 	}

--- a/disk_update.go
+++ b/disk_update.go
@@ -14,7 +14,7 @@ func (o *oVirtClient) UpdateDisk(id DiskID, params UpdateDiskParameters, retries
 ) {
 	progress, err := o.StartUpdateDisk(id, params, retries...)
 	if err != nil {
-		return progress.Disk(), err
+		return nil, err
 	}
 	return progress.Wait(retries...)
 }

--- a/disk_uploadimage.go
+++ b/disk_uploadimage.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 
@@ -621,7 +620,7 @@ func (m *mockImageUploadProgress) do() {
 		m.err = fmt.Errorf("failed to seek to start of image file (%w)", err)
 		return
 	}
-	m.disk.data, err = ioutil.ReadAll(m.reader)
+	m.disk.data, err = io.ReadAll(m.reader)
 	m.err = err
 	if err != nil {
 		m.uploadedBytes = m.size

--- a/errors.go
+++ b/errors.go
@@ -242,7 +242,7 @@ func newError(code ErrorCode, format string, args ...interface{}) EngineError {
 // this function will attempt to identify the error deeper.
 func wrap(err error, code ErrorCode, format string, args ...interface{}) EngineError {
 	// gocritic will complain on the following line due to appendAssign, but that's legit here.
-	realArgs := append(args, err) // nolint:gocritic
+	realArgs := append(args, err) //nolint:gocritic
 	realMessage := fmt.Sprintf(fmt.Sprintf("%s (%v)", format, "%v"), realArgs...)
 	if code == EUnidentified {
 		var realErr EngineError

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,6 +1,6 @@
 // This file contains tests for the internal retry functionality. It is therefore excluded from the testpackage check.
 
-package ovirtclient // nolint:testpackage
+package ovirtclient //nolint:testpackage
 
 import (
 	"context"

--- a/scripts/get_test_image/get_test_image.go
+++ b/scripts/get_test_image/get_test_image.go
@@ -54,7 +54,7 @@ func downloadTestImage(source string, target string) {
 	}
 	log.Printf("Downloading test image from %s to %s...", source, target)
 	// There is no file inclusion vulnerability here.
-	targetFh, err := os.Create(target) // nolint:gosec
+	targetFh, err := os.Create(target) //nolint:gosec
 	if err != nil {
 		log.Fatalf("failed to create temporary image file at %s (%v)", target, err)
 	}

--- a/scripts/rest/rest.go
+++ b/scripts/rest/rest.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -60,7 +60,7 @@ func main() {
 		secondaryID,
 		idType,
 	}
-	files, err := ioutil.ReadDir(tplDir)
+	files, err := os.ReadDir(tplDir)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -119,7 +119,7 @@ func getParameters() (string, string, string, string, string, string, bool, bool
 
 // setupFlags sets up the command line flags. This function is annotated with nolint:funlen since there is no reasonable
 // way to split this function and still keeping the code simple.
-func setupFlags( // nolint:funlen
+func setupFlags( //nolint:funlen
 	name *string,
 	id *string,
 	secondaryID *string,
@@ -206,14 +206,14 @@ func setupFlags( // nolint:funlen
 func handleTemplateFile(templateFileName string, id string, targetDir string, restItem restItem, nofmt bool) error {
 	// We are working through all template files here, so including these files is intentional
 	// and not a security issue.
-	fh, err := os.Open(templateFileName) // nolint:gosec
+	fh, err := os.Open(templateFileName) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed to open %s (%w)", templateFileName, err)
 	}
 	defer func() {
 		_ = fh.Close()
 	}()
-	data, err := ioutil.ReadAll(fh)
+	data, err := io.ReadAll(fh)
 	if err != nil {
 		return fmt.Errorf("failed to read %s (%w)", templateFileName, err)
 	}

--- a/tls.go
+++ b/tls.go
@@ -3,7 +3,7 @@ package ovirtclient
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sync"
@@ -186,7 +186,7 @@ func (s *standardTLSProvider) CreateTLSConfig() (*tls.Config, error) {
 
 func (s *standardTLSProvider) addCertsFromDir(certPool *x509.CertPool) error {
 	for _, dir := range s.directories {
-		files, err := ioutil.ReadDir(dir.dir)
+		files, err := os.ReadDir(dir.dir)
 		if err != nil {
 			return wrap(
 				err,
@@ -212,7 +212,7 @@ func (s *standardTLSProvider) addCertsFromDir(certPool *x509.CertPool) error {
 				}
 			}
 			fullPath := filepath.Join(dir.dir, info.Name())
-			data, err := ioutil.ReadFile(fullPath) // nolint:gosec
+			data, err := os.ReadFile(fullPath) //nolint:gosec
 			if err != nil {
 				return wrap(
 					err,
@@ -235,7 +235,7 @@ func (s *standardTLSProvider) addCertsFromDir(certPool *x509.CertPool) error {
 
 func (s *standardTLSProvider) addCertsFromFile(certPool *x509.CertPool) error {
 	for _, file := range s.files {
-		pemData, err := ioutil.ReadFile(file) //nolint:gosec
+		pemData, err := os.ReadFile(file) //nolint:gosec
 		if err != nil {
 			return wrap(err, EFileReadFailed, "failed to read CA certificate from file %s", file)
 		}

--- a/util_random.go
+++ b/util_random.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 )
 
-var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") // nolint:gochecknoglobals
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") //nolint:gochecknoglobals
 
 func generateRandomID(length uint, r *rand.Rand) string {
 	b := make([]byte, length)

--- a/util_test.go
+++ b/util_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	nextFreePortLock = &sync.Mutex{} // nolint:gochecknoglobals
+	nextFreePortLock = &sync.Mutex{} //nolint:gochecknoglobals
 )
 
 func getNextFreePort(t *testing.T) int {

--- a/vm.go
+++ b/vm.go
@@ -2499,7 +2499,7 @@ type VMStatusList []VMStatus
 // Copy creates a separate copy of the current status list.
 func (l VMStatusList) Copy() VMStatusList {
 	result := make([]VMStatus, len(l))
-	// nolint:gosimple
+	//nolint:gosimple
 	for i, s := range l {
 		result[i] = s
 	}


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes a panic due to a nil reference when the `StartUpdateDisk` function fails. 

Update: 
Due to using golangci-lint v1.48.0 and Go 1.19 in the pipeline, there are additional lint fixes. Among them is the replacement of the deprecated `io/ioutil` package. Functions from this package where replaced according to documentation: https://pkg.go.dev/io/ioutil

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
