### PR TITLE
OCPRHV-856 - removed error log for console not found

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,4 +103,5 @@ issues:
       source: "//"
     - linters:
         - gofmt
+        - revive
       source: "/*"

--- a/instancetype_get.go
+++ b/instancetype_get.go
@@ -1,4 +1,4 @@
-package ovirtclient
+package ovirtclient //nolint:dupl
 
 import (
 	"fmt"

--- a/vm.go
+++ b/vm.go
@@ -2106,7 +2106,7 @@ func validateVMName(name string) error {
 	return nil
 }
 
-func convertSDKVM(sdkObject *ovirtsdk.Vm, client Client, logger Logger, action string) (VM, error) {
+func convertSDKVM(sdkObject *ovirtsdk.Vm, client Client) (VM, error) {
 	vmObject := &vm{
 		client: client,
 	}
@@ -2129,6 +2129,7 @@ func convertSDKVM(sdkObject *ovirtsdk.Vm, client Client, logger Logger, action s
 		vmTypeConverter,
 		vmOSConverter,
 		vmSoundcardEnabledConverter,
+		vmSerialConsoleConverter,
 	}
 	for _, converter := range vmConverters {
 		if err := converter(sdkObject, vmObject); err != nil {
@@ -2136,31 +2137,18 @@ func convertSDKVM(sdkObject *ovirtsdk.Vm, client Client, logger Logger, action s
 		}
 	}
 
-	if err := vmSerialConsoleConverter(sdkObject, vmObject, logger, action); err != nil {
-		return nil, err
-	}
-
 	return vmObject, nil
 }
 
-func vmSerialConsoleConverter(object *ovirtsdk.Vm, v *vm, logger Logger, action string) error {
+func vmSerialConsoleConverter(object *ovirtsdk.Vm, v *vm) error {
+	// console is excluded from the response from oVirt engine by default. Therefore, using the default bool value as return value
+	// see: http://ovirt.github.io/ovirt-engine-api-model/master/#services/vm/methods/get/parameters/all_content
 	console, ok := object.Console()
 	if !ok {
-		// This sometimes (?) happens, and we don't know why. We will assume the serial console does not exist,
-		// otherwise we create a flaky behavior.
-		//
-		// See these issues:
-		// - https://github.com/oVirt/terraform-provider-ovirt/issues/411
-		// - https://github.com/oVirt/go-ovirt-client/issues/211
-		logger.Warningf(
-			"If you see this message, please open a Bugzilla entry with your oVirt version! The virtual machine object was returned from the oVirt Engine while %s without a console sub-object. VM: %s status: %s",
-			action,
-			object.MustId(),
-			object.MustStatus(),
-		)
 		v.serialConsole = false
 		return nil
 	}
+
 	enabled, ok := console.Enabled()
 	if !ok {
 		return newFieldNotFound("serial console", "enabled")
@@ -2171,7 +2159,7 @@ func vmSerialConsoleConverter(object *ovirtsdk.Vm, v *vm, logger Logger, action 
 
 func vmSoundcardEnabledConverter(object *ovirtsdk.Vm, v *vm) error {
 	// soundcard_enabled is excluded from the response from oVirt engine by default. Therefore, using the default bool value as return value
-	// see: http://ovirt.github.io/ovirt-engine-api-model/master/#services/disk/methods/get/parameters/all_content
+	// see: http://ovirt.github.io/ovirt-engine-api-model/master/#services/vm/methods/get/parameters/all_content
 	soundcardEnabled, ok := object.SoundcardEnabled()
 	if !ok {
 		v.soundcardEnabled = false

--- a/vm_create.go
+++ b/vm_create.go
@@ -122,7 +122,7 @@ func (o *oVirtClient) CreateVM(clusterID ClusterID, templateID TemplateID, name 
 			if !ok {
 				return newError(EFieldMissing, "missing VM in VM create response")
 			}
-			result, err = convertSDKVM(vm, o, o.logger, "creating VM")
+			result, err = convertSDKVM(vm, o)
 			if err != nil {
 				return wrap(
 					err,

--- a/vm_get.go
+++ b/vm_get.go
@@ -1,4 +1,4 @@
-package ovirtclient
+package ovirtclient //nolint:dupl
 
 import (
 	"fmt"
@@ -23,7 +23,7 @@ func (o *oVirtClient) GetVM(id VMID, retries ...RetryStrategy) (result VM, err e
 					id,
 				)
 			}
-			result, err = convertSDKVM(sdkObject, o, o.logger, "getting VM")
+			result, err = convertSDKVM(sdkObject, o)
 			if err != nil {
 				return wrap(
 					err,

--- a/vm_get_by_name.go
+++ b/vm_get_by_name.go
@@ -20,7 +20,7 @@ func (o *oVirtClient) GetVMByName(name string, retries ...RetryStrategy) (result
 				if mName, ok := sdkObject.Name(); ok {
 					// We re-scan for the name here since the search function may result other VMs too.
 					if name == mName {
-						result, err = convertSDKVM(sdkObject, o, o.logger, "getting VM by name")
+						result, err = convertSDKVM(sdkObject, o)
 						return err
 					}
 				}

--- a/vm_list.go
+++ b/vm_list.go
@@ -1,4 +1,4 @@
-package ovirtclient
+package ovirtclient //nolint:dupl
 
 func (o *oVirtClient) ListVMs(retries ...RetryStrategy) (result []VM, err error) {
 	retries = defaultRetries(retries, defaultReadTimeouts(o))
@@ -18,7 +18,7 @@ func (o *oVirtClient) ListVMs(retries ...RetryStrategy) (result []VM, err error)
 			}
 			result = make([]VM, len(sdkObjects.Slice()))
 			for i, sdkObject := range sdkObjects.Slice() {
-				result[i], e = convertSDKVM(sdkObject, o, o.logger, "listing VMs")
+				result[i], e = convertSDKVM(sdkObject, o)
 				if e != nil {
 					return wrap(e, EBug, "failed to convert vm during listing item #%d", i)
 				}

--- a/vm_search.go
+++ b/vm_search.go
@@ -103,7 +103,7 @@ func (o *oVirtClient) SearchVMs(params VMSearchParameters, retries ...RetryStrat
 			}
 			result = make([]VM, len(sdkObjects.Slice()))
 			for i, sdkObject := range sdkObjects.Slice() {
-				result[i], e = convertSDKVM(sdkObject, o, o.logger, "searching for VMs")
+				result[i], e = convertSDKVM(sdkObject, o)
 				if e != nil {
 					return wrap(e, EBug, "failed to convert VM during searching item #%d", i)
 				}

--- a/vm_update.go
+++ b/vm_update.go
@@ -38,7 +38,7 @@ func (o *oVirtClient) UpdateVM(
 			if !ok {
 				return newError(EFieldMissing, "missing VM in VM update response")
 			}
-			result, err = convertSDKVM(vm, o, o.logger, "updating VM")
+			result, err = convertSDKVM(vm, o)
 			if err != nil {
 				return wrap(
 					err,


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes [OCPRHV-856](https://issues.redhat.com/browse/OCPRHV-856) by removing the log statement (as well as fixing some lint errors). 

As stated in the [oVirt engine api documentation](http://ovirt.github.io/ovirt-engine-api-model/master/#services/vm/methods/get/parameters/all_content), the `console` field is only returned if the query parameter `all_content` is set to true. Due to performance issues this parameter is always false and will, therefore, never return the console object. 


## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
