### PR TITLE
Extend vm description

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,13 +77,17 @@ linters:
     # endregion
 linters-settings:
   depguard:
-    list-type: whitelist
-    include-go-root: false
-    packages:
-      - github.com/ovirt/go-ovirt
-      - github.com/ovirt/go-ovirt-client/v3
-      - github.com/ovirt/go-ovirt-client-log/v3
-      - github.com/google/uuid
+    rules:
+      main:
+        files:
+          - "**/*.go"
+        allow:
+          - $gostd
+          - github.com/ovirt/go-ovirt
+          - github.com/ovirt/go-ovirt-client/v3
+          - github.com/ovirt/go-ovirt-client-log/v3
+          - github.com/google/uuid
+
   govet:
     enable-all: true
     check-shadowing: false

--- a/vm_create.go
+++ b/vm_create.go
@@ -18,6 +18,12 @@ func vmBuilderComment(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) 
 	}
 }
 
+func vmBuilderDescription(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) {
+	if description := params.Description(); description != "" {
+		builder.Description(description)
+	}
+}
+
 func vmBuilderCPU(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) {
 	if cpu := params.CPU(); cpu != nil {
 		cpuBuilder := ovirtsdk.NewCpuBuilder()
@@ -148,6 +154,7 @@ func createSDKVM(
 	builder.Name(name)
 	parts := []vmBuilderComponent{
 		vmBuilderComment,
+		vmBuilderDescription,
 		vmBuilderCPU,
 		vmBuilderHugePages,
 		vmBuilderInitialization,
@@ -416,6 +423,7 @@ func (m *mockClient) createVM(
 		VMID(id),
 		name,
 		params.Comment(),
+		params.Description(),
 		clusterID,
 		templateID,
 		VMStatusDown,

--- a/vm_test.go
+++ b/vm_test.go
@@ -66,7 +66,7 @@ func TestAfterVMCreationShouldBePresent(t *testing.T) {
 	}
 
 	updatedVM, err := fetchedVM.Update(
-		ovirtclient.UpdateVMParams().MustWithName("new_name").MustWithComment("new comment"),
+		ovirtclient.UpdateVMParams().MustWithName("new_name").MustWithComment("new comment").MustWithDescription("new description"),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -79,6 +79,9 @@ func TestAfterVMCreationShouldBePresent(t *testing.T) {
 	}
 	if updatedVM.Comment() != "new comment" {
 		t.Fatalf("updated VM comment %s does not match update parameters", updatedVM.Comment())
+	}
+	if updatedVM.Description() != "new description" {
+		t.Fatalf("updated VM description %s does not match update parameters", updatedVM.Description())
 	}
 
 	fetchedVM, err = client.GetVM(vm.ID())
@@ -94,6 +97,9 @@ func TestAfterVMCreationShouldBePresent(t *testing.T) {
 	if fetchedVM.Comment() != "new comment" {
 		t.Fatalf("updated VM comment %s does not match update parameters", fetchedVM.Comment())
 	}
+	if fetchedVM.Description() != "new description" {
+		t.Fatalf("updated VM description %s does not match update parameters", fetchedVM.Description())
+	}
 }
 
 func TestVMCreationWithCPU(t *testing.T) {
@@ -104,6 +110,7 @@ func TestVMCreationWithCPU(t *testing.T) {
 	}
 	for name, param := range params {
 		t.Run(name, func(t *testing.T) {
+			param := param
 			t.Parallel()
 			helper := getHelper(t)
 			vm := assertCanCreateVM(
@@ -228,6 +235,24 @@ func TestVMCreationWithInit(t *testing.T) {
 	if vm2.Initialization().HostName() != "test-vm" {
 		t.Fatalf("got Unexpected output from the HostName (%s) init field ", vm2.Initialization().HostName())
 	}
+}
+
+func TestVMCreationWithDescription(t *testing.T) {
+	t.Parallel()
+	testDescription := "test description"
+	helper := getHelper(t)
+	vm := assertCanCreateVM(
+		t,
+		helper,
+		fmt.Sprintf("test-%s", helper.GenerateRandomID(5)),
+		ovirtclient.CreateVMParams().MustWithDescription(testDescription),
+	)
+
+	description := vm.Description()
+	if description != testDescription {
+		t.Fatalf("Creating a VM with Description settings did not return a VM with expected Description , %s , %s.", description, testDescription)
+	}
+
 }
 
 // TestVMStartStop creates a micro VM with a tiny operating system, starts it and then stops it. The OS doesn't support

--- a/vm_update.go
+++ b/vm_update.go
@@ -24,6 +24,9 @@ func (o *oVirtClient) UpdateVM(
 	if comment := params.Comment(); comment != nil {
 		vm.SetComment(*comment)
 	}
+	if description := params.Description(); description != nil {
+		vm.SetDescription(*description)
+	}
 
 	err = retry(
 		fmt.Sprintf("updating vm %s", id),
@@ -70,6 +73,9 @@ func (m *mockClient) UpdateVM(id VMID, params UpdateVMParameters, _ ...RetryStra
 	}
 	if comment := params.Comment(); comment != nil {
 		vm = vm.withComment(*comment)
+	}
+	if description := params.Description(); description != nil {
+		vm = vm.withDescription(*description)
 	}
 	m.vms[id] = vm
 


### PR DESCRIPTION
## Changes

Extend ability of go-ovirt-client to work with Description of VM. 

oVirt SDK can work with Description but go-ovirt-client lost one.
It PR add ability to work with Description

## Are you the owner of the code you are sending in, or do you have permission of the owner?

It code is written by me personally on personal workstation in my spare time.

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

I agree with BSD 3 license
