### PR TITLE
fix: Update module name to github.com/dyudin0821/go-ovirt-client/v3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: janosdebugs
+assignees: dyudin0821
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,7 +3,7 @@ name: Documentation request
 about: If you think something is not well described
 title: ''
 labels: documentation
-assignees: janosdebugs
+assignees: dyudin0821
 ---
 
 ## Please describe what information you were trying to find

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: feature
-assignees: janosdebugs
+assignees: dyudin0821
 ---
 
 ## Please describe what you would like to see

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,14 @@ jobs:
           go-version: '1.20'
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v2
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-test-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-test-
+          key: go-test-v1-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-test-v1-${{ runner.os }}-
       - name: Run go test
         run: |
           set -euo pipefail
@@ -56,13 +57,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.20'
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-generate-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-generate-
+          key: go-generate-v1-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-generate-v1-${{ runner.os }}-
       - name: Run go generate
         run: ./.github/scripts/gogenerate.sh
   rpm:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.0.0
   test:
     name: go test
     runs-on: ubuntu-latest
@@ -20,9 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v2
       - uses: actions/cache@v3
@@ -38,7 +40,7 @@ jobs:
           go generate
           go test -json -v -client=mock ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
       - name: Upload test log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-log
@@ -51,9 +53,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/cache@v3
         with:
           path: |
@@ -79,9 +81,9 @@ jobs:
         run: |
           yum install -y git createrepo_c rpm-build golang make
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: Checkout
         uses: actions/checkout@v3
       - name : Compile go-ovirt-client tests and Build go-ovirt-client-tests RPM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-test-${{ hashFiles('**/go.sum') }}
+          key: go-generate-${{ hashFiles('**/go.sum') }}
           restore-keys: go-generate-
       - name: Run go generate
         run: ./.github/scripts/gogenerate.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.0.0
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.20
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v2
       - uses: actions/cache@v3
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.20
       - uses: actions/cache@v3
         with:
           path: |
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.20
       - name: Checkout
         uses: actions/checkout@v3
       - name : Compile go-ovirt-client tests and Build go-ovirt-client-tests RPM

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,7 @@ linters:
           allow:
             - $gostd
             - github.com/ovirt/go-ovirt
-            - github.com/ovirt/go-ovirt-client/v3
+            - github.com/dyudin0821/go-ovirt-client/v3
             - github.com/ovirt/go-ovirt-client-log/v3
             - github.com/google/uuid
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,111 +1,56 @@
+version: "2"
+
 run:
   timeout: 5m
+
 linters:
   enable:
-    # region General
-
-    # Add depguard to prevent adding additional dependencies. This is a client library, we really don't want
-    # additional dependencies.
+    # General
     - depguard
-    # Prevent improper directives in go.mod.
     - gomoddirectives
-    # Prevent improper nolint directives.
     - nolintlint
 
-    # endregion
-
-
-    # region Code Quality and Comments
-
-    # Inspect source code for potential security problems. This check has a fairly high false positive rate,
-    # comment with //nolint:gosec where not relevant.
+    # Code Quality
     - gosec
-    # Replace golint.
     - revive
-    # Complain about deeply nested if cases.
     - nestif
-    # Prevent naked returns in long functions.
     - nakedret
-    # Make Go code more readable.
     - gocritic
-    # We don't want hidden global scope, so disallow global variables. You can disable this with
-    # Check if comments end in a period. This helps prevent incomplete comment lines, such as half-written sentences.
     - godot
-    # Complain about comments as these indicate incomplete code.
     - godox
-    # Keep the cyclomatic complexity of functions to a reasonable level.
     - gocyclo
-    # Complain about cognitive complexity of functions.
     - gocognit
-    # Find repeated strings that could be converted into constants.
     - goconst
-    # Complain about unnecessary type conversions.
     - unconvert
-    # Complain about unused parameters. These should be replaced with underscores.
     - unparam
-    # Check for non-ASCII identifiers.
     - asciicheck
-    # Check for HTTP response body being closed. Sometimes, you may need to disable this using //nolint:bodyclose.
     - bodyclose
-    # Check for duplicate code. You may want to disable this with //nolint:dupl if the source code is the same, but
-    # legitimately exists for different reasons.
     - dupl
-    # Check for pointers in loops. This is a typical bug source.
-    - exportloopref
-    # Enforce a reasonable function length of 60 lines or 40 instructions. In very rare cases you may want to disable
-    # this with //nolint:funlen if there is absolutely no way to split the function in question.
     - funlen
-    # Prevent dogsledding (mass-ignoring return values). This typically indicates missing error handling.
     - dogsled
-    # Enforce consistent import aliases across all files.
     - importas
-    # Make package imports always deterministic.
-    - gci
-    # Make code properly formatted.
-    - gofmt
-    # Prevent faulty error checks.
     - nilerr
-    # Prevent direct error checks that won't work with wrapped errors.
     - errorlint
-    # Find slice usage that could potentially be preallocated.
     - prealloc
-    # Check for improper duration handling.
     - durationcheck
-    # Enforce tests being in the _test package.
-    - testpackage
+    - testableexamples
 
-    # endregion
-linters-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - "**/*.go"
-        allow:
-          - $gostd
-          - github.com/ovirt/go-ovirt
-          - github.com/ovirt/go-ovirt-client/v3
-          - github.com/ovirt/go-ovirt-client-log/v3
-          - github.com/google/uuid
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "**/*.go"
+          allow:
+            - $gostd
+            - github.com/ovirt/go-ovirt
+            - github.com/ovirt/go-ovirt-client/v3
+            - github.com/ovirt/go-ovirt-client-log/v3
+            - github.com/google/uuid
 
-  govet:
-    enable-all: true
-    check-shadowing: false
-    disable:
-      # Remove this in a future PR to optimize struct usage.
-      - fieldalignment
-      # We don't care about variable shadowing.
-      - shadow
-  stylecheck:
-    checks:
-      - all
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - gofmt
-      source: "//"
-    - linters:
-        - gofmt
-        - revive
-      source: "/*"
+    govet:
+      enable-all: true
+      # check-shadowing: false
+      disable:
+        - fieldalignment
+        - shadow

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ package main
 import (
 	"crypto/x509"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 
@@ -122,7 +122,7 @@ import (
 	"os"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 )
 

--- a/affinitygroup_test.go
+++ b/affinitygroup_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func assertCanCreateAffinityGroup(t *testing.T, helper ovirtclient.TestHelper, params ovirtclient.CreateAffinityGroupOptionalParams) ovirtclient.AffinityGroup {

--- a/disk.go
+++ b/disk.go
@@ -717,8 +717,8 @@ func convertSDKDisk(sdkDisk *ovirtsdk4.Disk, client Client) (Disk, error) {
 
 		id:               DiskID(id),
 		alias:            alias,
-		provisionedSize:  uint64(provisionedSize),
-		totalSize:        uint64(totalSize),
+		provisionedSize:  uint64(provisionedSize), //nolint:gosec
+		totalSize:        uint64(totalSize),       //nolint:gosec
 		format:           ImageFormat(format),
 		storageDomainIDs: storageDomainIDs,
 		status:           DiskStatus(status),

--- a/disk_attachment_test.go
+++ b/disk_attachment_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestDiskAttachmentCreation(t *testing.T) {

--- a/disk_attachment_test.go
+++ b/disk_attachment_test.go
@@ -162,7 +162,7 @@ func assertDiskAttachmentCount(t *testing.T, vm ovirtclient.VM, count uint) {
 	if err != nil {
 		t.Fatalf("Failed to list disk attachments for VM %s (%v)", vm.ID(), err)
 	}
-	if len(attachments) != int(count) {
+	if uint(len(attachments)) != count {
 		t.Fatalf("Invalid number of attachments on VM %s, expected %d, is %d", vm.ID(), count, len(attachments))
 	}
 }

--- a/disk_create.go
+++ b/disk_create.go
@@ -116,11 +116,14 @@ func (o *oVirtClient) buildDiskObjectForCreation(
 			storageDomainID,
 		)
 	}
+	if size > 9223372036854775807 { // max int64
+		return nil, newError(EBadArgument, "disk size exceeds maximum allowed value")
+	}
 	diskBuilder := ovirtsdk4.NewDiskBuilder().
 		ProvisionedSize(int64(size)).
 		StorageDomainsOfAny(storageDomain).
 		Format(ovirtsdk4.DiskFormat(format))
-	if params != nil {
+	if params != nil { //nolint:nestif
 		if sparse := params.Sparse(); sparse != nil {
 			diskBuilder.Sparse(*sparse)
 		}
@@ -128,6 +131,9 @@ func (o *oVirtClient) buildDiskObjectForCreation(
 			diskBuilder.Alias(alias)
 		}
 		if initialSize := params.InitialSize(); initialSize != nil {
+			if *initialSize > 9223372036854775807 { // max int64
+				return nil, newError(EBadArgument, "initial size exceeds maximum allowed value")
+			}
 			diskBuilder.InitialSize(int64(*initialSize))
 		}
 	}

--- a/disk_create_mock.go
+++ b/disk_create_mock.go
@@ -59,10 +59,10 @@ func (m *mockClient) createDisk(
 
 	if params != nil {
 		if alias := params.Alias(); alias != "" {
-			disk.disk.alias = alias
+			disk.alias = alias
 		}
 		if sparse := params.Sparse(); sparse != nil {
-			disk.disk.sparse = *sparse
+			disk.sparse = *sparse
 		}
 	}
 

--- a/disk_downloadimage.go
+++ b/disk_downloadimage.go
@@ -243,7 +243,9 @@ func (i *imageDownload) Read(p []byte) (n int, err error) {
 	n, err = i.reader.Read(p)
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	i.bytesRead += uint64(n)
+	if n > 0 {
+		i.bytesRead += uint64(n)
+	}
 
 	if i.bytesRead == i.size {
 		go func() {
@@ -372,7 +374,9 @@ func (m *mockImageDownload) Read(p []byte) (n int, err error) {
 	if err != nil {
 		m.lastError = err
 	}
-	m.bytesRead += uint64(n)
+	if n > 0 {
+		m.bytesRead += uint64(n)
+	}
 
 	if m.bytesRead == m.size {
 		go func() {

--- a/disk_downloadimage_test.go
+++ b/disk_downloadimage_test.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestImageDownload(t *testing.T) {

--- a/disk_downloadimage_test.go
+++ b/disk_downloadimage_test.go
@@ -99,7 +99,7 @@ func getFullTestImage(t *testing.T) (io.ReadSeekCloser, uint64, uint64) {
 		t.Fatalf("cannot read QCOW header from full test image (%v)", err)
 	}
 
-	return &nopReadCloser{bytes.NewReader(fullTestImage)}, uint64(size), header.Size
+	return &nopReadCloser{bytes.NewReader(fullTestImage)}, uint64(size), header.Size //nolint:gosec
 }
 
 func getTestImageFile(t *testing.T) (io.ReadSeekCloser, uint64) {
@@ -133,7 +133,7 @@ func getTestImageData(t *testing.T) ([]byte, uint64) {
 	if err != nil {
 		t.Errorf("testimage/image not found in the test environment. (%v)", err)
 	}
-	return testImage, uint64(size)
+	return testImage, uint64(size) //nolint:gosec
 }
 
 func downloadImage(

--- a/disk_remove_test.go
+++ b/disk_remove_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // TestDiskRemoveFromStoppedVMShouldNotResultInError tests if removing a disk from under a stopped VM does not result

--- a/disk_test.go
+++ b/disk_test.go
@@ -32,7 +32,7 @@ func ExampleDiskClient_CreateDisk() {
 	disk, err := client.CreateDisk(
 		storageDomainID,
 		imageFormat,
-		uint64(diskSize),
+		uint64(diskSize), //nolint:gosec
 		ovirtclient.CreateDiskParams().MustWithAlias("test_disk"),
 	)
 	if err != nil {

--- a/disk_test.go
+++ b/disk_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // ExampleDiskClient_CreateDisk is an example of creating an empty disk. This example works with the test

--- a/disk_update.go
+++ b/disk_update.go
@@ -30,6 +30,9 @@ func (o *oVirtClient) StartUpdateDisk(id DiskID, params UpdateDiskParameters, re
 		sdkDisk.Alias(*alias)
 	}
 	if provisionedSize := params.ProvisionedSize(); provisionedSize != nil {
+		if *provisionedSize > 9223372036854775807 { // max int64
+			return nil, newError(EBadArgument, "provisioned size exceeds maximum allowed value")
+		}
 		sdkDisk.ProvisionedSize(int64(*provisionedSize))
 	}
 	correlationID := fmt.Sprintf("disk_update_%s", generateRandomID(5, o.nonSecureRandom))

--- a/disk_update_test.go
+++ b/disk_update_test.go
@@ -3,7 +3,7 @@ package ovirtclient_test
 import (
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestExtendDisk(t *testing.T) {

--- a/disk_uploadimage.go
+++ b/disk_uploadimage.go
@@ -233,7 +233,7 @@ func (u *uploadToDiskProgress) putRequest(transferURL string, transfer imageTran
 		return wrap(err, EUnidentified, "failed to create HTTP request")
 	}
 	putRequest.Header.Add("content-type", "application/octet-stream")
-	putRequest.ContentLength = int64(u.totalBytes)
+	putRequest.ContentLength = int64(u.totalBytes) //nolint:gosec
 	putRequest.Body = u
 	response, err := u.client.httpClient.Do(putRequest)
 	if err != nil {
@@ -290,7 +290,9 @@ func (u *uploadToDiskProgress) Read(p []byte) (n int, err error) {
 	default:
 	}
 	n, err = u.reader.Read(p)
-	u.transferredBytes += uint64(n)
+	if n > 0 {
+		u.transferredBytes += uint64(n)
+	}
 	return
 }
 
@@ -386,7 +388,7 @@ func (u *uploadToNewDiskProgress) Do() {
 
 	u.updateDisk(disk)
 
-	err = u.uploadToDiskProgress.transfer()
+	err = u.transfer()
 	u.lock.Lock()
 	u.err = err
 	u.lock.Unlock()

--- a/disk_uploadimage_test.go
+++ b/disk_uploadimage_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func assertCanUploadDiskImage(t *testing.T, helper ovirtclient.TestHelper, disk ovirtclient.Disk) {

--- a/disk_wait_for_ok.go
+++ b/disk_wait_for_ok.go
@@ -44,7 +44,7 @@ func (o *oVirtClient) checkDiskOK(diskID DiskID) (Disk, error) {
 // WaitForDiskOK waits for a disk to be in the OK status, then additionally queries the job that was in progress with
 // the correlation ID. This is necessary because the disk returns OK status before the job has actually finished,
 // resulting in a "disk locked" error on subsequent operations. It uses checkDiskOk as an underlying function.
-func (m *mockClient) WaitForDiskOK(diskID DiskID, retries ...RetryStrategy) (Disk, error) {
+func (m *mockClient) WaitForDiskOK(diskID DiskID, _ ...RetryStrategy) (Disk, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	disk, ok := m.disks[diskID]

--- a/doc.go
+++ b/doc.go
@@ -110,7 +110,7 @@ You can also create the test helper manually:
         "os"
         "testing"
 
-        ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+        ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
         ovirtclientlog "github.com/ovirt/go-ovirt-client-log"
     )
 

--- a/example_vm_create_test.go
+++ b/example_vm_create_test.go
@@ -37,4 +37,5 @@ func ExampleVMClient_create() {
 	if err := vm.Remove(); err != nil {
 		panic(fmt.Sprintf("failed to remove VM (%v)", err))
 	}
+	// Output:
 }

--- a/example_vm_create_test.go
+++ b/example_vm_create_test.go
@@ -9,7 +9,7 @@ import (
 
 // The following example demonstrates how to create a virtual machine. It is set up
 // using the test helper, but can be easily modified to use the client directly.
-func ExampleVMClient_create() {
+func ExampleVMClient_create() { //nolint:testableexamples
 	// Create the helper for testing. Alternatively, you could create a production client with ovirtclient.New()
 	helper, err := ovirtclient.NewLiveTestHelperFromEnv(ovirtclientlog.NewNOOPLogger())
 	if err != nil {
@@ -37,5 +37,4 @@ func ExampleVMClient_create() {
 	if err := vm.Remove(); err != nil {
 		panic(fmt.Sprintf("failed to remove VM (%v)", err))
 	}
-	// Output:
 }

--- a/example_vm_create_test.go
+++ b/example_vm_create_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // The following example demonstrates how to create a virtual machine. It is set up

--- a/example_vm_list_test.go
+++ b/example_vm_list_test.go
@@ -24,4 +24,5 @@ func ExampleVMClient_list() {
 	for _, vm := range vms {
 		fmt.Printf("Found VM %s\n", vm.ID())
 	}
+	// Output:
 }

--- a/example_vm_list_test.go
+++ b/example_vm_list_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // The following example demonstrates how to list virtual machines.
-func ExampleVMClient_list() {
+func ExampleVMClient_list() { //nolint:testableexamples
 	// Create the helper for testing. Alternatively, you could create a production client with ovirtclient.New()
 	helper, err := ovirtclient.NewLiveTestHelperFromEnv(ovirtclientlog.NewNOOPLogger())
 	if err != nil {
@@ -24,5 +24,4 @@ func ExampleVMClient_list() {
 	for _, vm := range vms {
 		fmt.Printf("Found VM %s\n", vm.ID())
 	}
-	// Output:
 }

--- a/example_vm_list_test.go
+++ b/example_vm_list_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // The following example demonstrates how to list virtual machines.

--- a/example_vm_uploadimage_test.go
+++ b/example_vm_uploadimage_test.go
@@ -12,7 +12,7 @@ import (
 
 // This example demonstrates the simplest way to upload an image without special timeout handling. The call still times
 // out after a built-in timeout.
-func ExampleDiskClient_uploadImage() {
+func ExampleDiskClient_uploadImage() { //nolint:testableexamples
 	// Open image file to upload
 	fh, err := os.Open("/path/to/test.img")
 	if err != nil {
@@ -51,11 +51,10 @@ func ExampleDiskClient_uploadImage() {
 		panic(fmt.Errorf("failed to upload image (%w)", err))
 	}
 	fmt.Printf("Uploaded as disk %s\n", uploadResult.Disk().ID())
-	// Output:
 }
 
 // This example demonstrates how to upload a VM image into a disk while being able to cancel the process manually.
-func ExampleDiskClient_uploadImageWithCancel() {
+func ExampleDiskClient_uploadImageWithCancel() { //nolint:testableexamples
 	// Open image file to upload
 	fh, err := os.Open("/path/to/test.img")
 	if err != nil {
@@ -112,5 +111,4 @@ func ExampleDiskClient_uploadImageWithCancel() {
 		panic(fmt.Errorf("failed to upload image (%w)", err))
 	}
 	fmt.Printf("Uploaded as disk %s\n", uploadResult.Disk().ID())
-	// Output:
 }

--- a/example_vm_uploadimage_test.go
+++ b/example_vm_uploadimage_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // This example demonstrates the simplest way to upload an image without special timeout handling. The call still times

--- a/example_vm_uploadimage_test.go
+++ b/example_vm_uploadimage_test.go
@@ -43,7 +43,7 @@ func ExampleDiskClient_uploadImage() {
 	uploadResult, err := client.UploadToNewDisk(
 		helper.GetStorageDomainID(),
 		ovirtclient.ImageFormatRaw,
-		uint64(stat.Size()),
+		uint64(stat.Size()), //nolint:gosec
 		ovirtclient.CreateDiskParams().MustWithAlias(imageName).MustWithSparse(true),
 		fh,
 	)
@@ -51,6 +51,7 @@ func ExampleDiskClient_uploadImage() {
 		panic(fmt.Errorf("failed to upload image (%w)", err))
 	}
 	fmt.Printf("Uploaded as disk %s\n", uploadResult.Disk().ID())
+	// Output:
 }
 
 // This example demonstrates how to upload a VM image into a disk while being able to cancel the process manually.
@@ -88,7 +89,7 @@ func ExampleDiskClient_uploadImageWithCancel() {
 	uploadResult, err := client.StartUploadToNewDisk(
 		helper.GetStorageDomainID(),
 		ovirtclient.ImageFormatRaw,
-		uint64(stat.Size()),
+		uint64(stat.Size()), //nolint:gosec
 		ovirtclient.CreateDiskParams().MustWithSparse(true).MustWithAlias(imageName),
 		fh,
 		ovirtclient.ContextStrategy(ctx),
@@ -111,4 +112,5 @@ func ExampleDiskClient_uploadImageWithCancel() {
 		panic(fmt.Errorf("failed to upload image (%w)", err))
 	}
 	fmt.Printf("Uploaded as disk %s\n", uploadResult.Disk().ID())
+	// Output:
 }

--- a/feature_test.go
+++ b/feature_test.go
@@ -3,7 +3,7 @@ package ovirtclient_test
 import (
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestFeatureFlags(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ovirt/go-ovirt-client/v3
+module github.com/dyudin0821/go-ovirt-client/v3
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/ovirt/go-ovirt-client/v3
 
-go 1.16
+go 1.20
 
 require (
 	github.com/google/uuid v1.3.0
 	github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c
 	github.com/ovirt/go-ovirt-client-log/v3 v3.0.0
-	github.com/stretchr/testify v1.7.0 // indirect
 )
+
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c/go.mod h1:Zkdj9/rW6
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 h1:uvACVHYhYPMkNJrrgWiABcfELB6qoFfsDDUTbpb4Jv4=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0/go.mod h1:chKKxCv4lRjxezrTG+EIhkWXGhDAWByglPVXh/iYdnQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 var getHelper func(t *testing.T) ovirtclient.TestHelper

--- a/new.go
+++ b/new.go
@@ -218,7 +218,7 @@ func getProxyFunc(extraSettings ExtraSettings) (func(req *http.Request) (*url.UR
 		if err != nil {
 			return nil, wrap(err, EBadArgument, "failed to parse proxy URL: %s", *proxy)
 		}
-		proxyFunc = func(req *http.Request) (*url.URL, error) {
+		proxyFunc = func(_ *http.Request) (*url.URL, error) {
 			return u, nil
 		}
 	} else {

--- a/new_context_test.go
+++ b/new_context_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 type ctxKey string

--- a/new_test.go
+++ b/new_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestBadOVirtURL(t *testing.T) {

--- a/new_test.go
+++ b/new_test.go
@@ -195,7 +195,7 @@ func TestCredentialChangeAfterSetup(t *testing.T) {
 		ovirtclient.TLS().CACertsFromMemory(realCABytes),
 		logger,
 		nil,
-		func(connection ovirtclient.Client) error {
+		func(_ ovirtclient.Client) error {
 			// Disable connection check on setup to simulate a credential shift after the connection
 			// has been established.
 			return nil

--- a/nic_create_test.go
+++ b/nic_create_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMNICCreation(t *testing.T) {

--- a/nic_test.go
+++ b/nic_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func assertCanUpdateNICName(t *testing.T, nic ovirtclient.NIC, name string) ovirtclient.NIC {

--- a/nic_update.go
+++ b/nic_update.go
@@ -55,7 +55,7 @@ func (o *oVirtClient) UpdateNIC(
 	return result, err
 }
 
-func (m *mockClient) UpdateNIC(vmid VMID, nicID NICID, params UpdateNICParameters, retries ...RetryStrategy) (
+func (m *mockClient) UpdateNIC(vmid VMID, nicID NICID, params UpdateNICParameters, _ ...RetryStrategy) (
 	NIC,
 	error,
 ) {

--- a/nic_update_test.go
+++ b/nic_update_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMNICUpdate(t *testing.T) {

--- a/scripts/get_test_image/get_test_image.go
+++ b/scripts/get_test_image/get_test_image.go
@@ -1,3 +1,4 @@
+// Package main provides a tool to download test images from GitHub repositories.
 package main
 
 import (
@@ -24,7 +25,7 @@ const defaultTestImageSource = "https://github.com/oVirt/ovirt-tinycore-linux"
 var gitHubCerts []byte
 var imageSourceGitHubPattern = regexp.MustCompile(`^https://github.com/([^/]+)/([^/]+)/?$`)
 var testImageDownloadHTTPClient = &http.Client{
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 		return nil
 	},
 	Transport: &http.Transport{

--- a/scripts/rest/rest.go
+++ b/scripts/rest/rest.go
@@ -1,3 +1,4 @@
+// Package main provides a code generation tool for REST API bindings.
 package main
 
 import (

--- a/tag_test.go
+++ b/tag_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestTagCreation(t *testing.T) {

--- a/template.go
+++ b/template.go
@@ -169,6 +169,9 @@ func convertSDKTemplateCPU(sdkObject *ovirtsdk.Template) (*vmCPU, error) {
 	if !ok {
 		return nil, newFieldNotFound("CPU topo in CPU in VM", "sockets")
 	}
+	if cores < 0 || threads < 0 || sockets < 0 {
+		return nil, newError(EBadArgument, "CPU topology values cannot be negative")
+	}
 	cpu := &vmCPU{
 		topo: &vmCPUTopo{
 			uint(cores),

--- a/template_copy_disk.go
+++ b/template_copy_disk.go
@@ -69,7 +69,7 @@ func (o *oVirtClient) StartCopyTemplateDiskToStorageDomain(
 func (m *mockClient) CopyTemplateDiskToStorageDomain(
 	diskID DiskID,
 	storageDomainID StorageDomainID,
-	retries ...RetryStrategy) (result Disk, err error) {
+	_ ...RetryStrategy) (result Disk, err error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	disk, ok := m.disks[diskID]

--- a/template_disk_list_test.go
+++ b/template_disk_list_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // TestTemplateDiskListAttachments tests if listing the disk attachments of a template works properly.

--- a/template_get_blank_test.go
+++ b/template_get_blank_test.go
@@ -3,7 +3,7 @@ package ovirtclient_test
 import (
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestTemplateBlank(t *testing.T) {

--- a/template_test.go
+++ b/template_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // TestTemplateCreation is the simplest test for creating and using a template.

--- a/tls_test.go
+++ b/tls_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 // This example shows how to set up TLS verification in a variety of ways.

--- a/vm.go
+++ b/vm.go
@@ -472,27 +472,32 @@ func (i *initialization) WithNicConfiguration(nic NicConfiguration) BuildableIni
 	return i
 }
 
-type IpVersion string
+// IPVersion represents the IP protocol version (v4 or v6).
+type IPVersion string
 
 const (
-	IPVERSION_V4 IpVersion = "v4"
-	IPVERSION_V6 IpVersion = "v6"
+	// IPVersionV4 represents IPv4 protocol version.
+	IPVersionV4 IPVersion = "v4"
+	// IPVersionV6 represents IPv6 protocol version.
+	IPVersionV6 IPVersion = "v6"
 )
 
-// Ip Represents the IP configuration of a network interface.
+// IP represents the IP configuration of a network interface.
 type IP struct {
 	Address string
 	Gateway string
 	Netmask string
-	Version IpVersion
+	Version IPVersion
 }
 
+// IsIPv4 returns true if the IP is an IPv4 address.
 func (ip IP) IsIPv4() bool {
-	return ip.Version == IPVERSION_V4
+	return ip.Version == IPVersionV4
 }
 
+// IsIPv6 returns true if the IP is an IPv6 address.
 func (ip IP) IsIPv6() bool {
-	return ip.Version == IPVERSION_V6
+	return ip.Version == IPVersionV6
 }
 
 // NicConfiguration defines a virtual machine’s initialization nic configuration.
@@ -584,7 +589,7 @@ func convertSDKNicConfiguration(sdkObject *ovirtsdk.NicConfiguration) NicConfigu
 			Address: ipv4.MustAddress(),
 			Gateway: ipv4.MustGateway(),
 			Netmask: ipv4.MustNetmask(),
-			Version: IPVERSION_V4,
+			Version: IPVersionV4,
 		},
 	)
 
@@ -600,7 +605,7 @@ func convertSDKNicConfiguration(sdkObject *ovirtsdk.NicConfiguration) NicConfigu
 				Address: address,
 				Gateway: gateway,
 				Netmask: netmask,
-				Version: IPVERSION_V6,
+				Version: IPVersionV6,
 			},
 		)
 	}
@@ -2721,9 +2726,9 @@ func convertSDKVMCPU(sdkObject *ovirtsdk.Vm) (*vmCPU, error) {
 	}
 	cpu := &vmCPU{
 		topo: &vmCPUTopo{
-			uint(cores),
-			uint(threads),
-			uint(sockets),
+			uint(cores),   //nolint:gosec
+			uint(threads), //nolint:gosec
+			uint(sockets), //nolint:gosec
 		},
 		mode: cpuMode,
 	}
@@ -2813,10 +2818,7 @@ type VMStatusList []VMStatus
 // Copy creates a separate copy of the current status list.
 func (l VMStatusList) Copy() VMStatusList {
 	result := make([]VMStatus, len(l))
-	//nolint:gosimple
-	for i, s := range l {
-		result[i] = s
-	}
+	copy(result, l)
 	return result
 }
 

--- a/vm_boot_test.go
+++ b/vm_boot_test.go
@@ -1,0 +1,193 @@
+package ovirtclient_test
+
+import (
+	"testing"
+
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
+	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+)
+
+func TestBootDevice(t *testing.T) {
+	t.Parallel()
+
+	// Test valid boot devices
+	validDevices := []ovirtclient.BootDevice{
+		ovirtclient.BootDeviceHD,
+		ovirtclient.BootDeviceNetwork,
+		ovirtclient.BootDeviceCDROM,
+	}
+
+	for _, device := range validDevices {
+		if err := device.Validate(); err != nil {
+			t.Fatalf("Valid boot device %s failed validation: %v", device, err)
+		}
+	}
+
+	// Test invalid boot device
+	invalidDevice := ovirtclient.BootDevice("invalid")
+	if err := invalidDevice.Validate(); err == nil {
+		t.Fatalf("Invalid boot device should have failed validation")
+	}
+}
+
+func TestBootDeviceValues(t *testing.T) {
+	t.Parallel()
+
+	devices := ovirtclient.BootDeviceValues()
+	if len(devices) != 3 {
+		t.Fatalf("Expected 3 boot device values, got %d", len(devices))
+	}
+
+	expected := map[ovirtclient.BootDevice]bool{
+		ovirtclient.BootDeviceHD:      true,
+		ovirtclient.BootDeviceNetwork: true,
+		ovirtclient.BootDeviceCDROM:   true,
+	}
+
+	for _, device := range devices {
+		if !expected[device] {
+			t.Fatalf("Unexpected boot device: %s", device)
+		}
+	}
+}
+
+func TestVMOSParametersWithBootDevices(t *testing.T) {
+	t.Parallel()
+
+	// Test WithBootDevices
+	osParams := ovirtclient.NewVMOSParameters()
+	bootDevices := []ovirtclient.BootDevice{
+		ovirtclient.BootDeviceNetwork,
+		ovirtclient.BootDeviceCDROM,
+		ovirtclient.BootDeviceHD,
+	}
+
+	osParams, err := osParams.WithBootDevices(bootDevices)
+	if err != nil {
+		t.Fatalf("Failed to set boot devices: %v", err)
+	}
+
+	if devices := osParams.BootDevices(); len(devices) != 3 {
+		t.Fatalf("Expected 3 boot devices, got %d", len(devices))
+	}
+
+	// Test WithBootDevice (adding one at a time)
+	osParams2 := ovirtclient.NewVMOSParameters()
+	osParams2, err = osParams2.WithBootDevice(ovirtclient.BootDeviceHD)
+	if err != nil {
+		t.Fatalf("Failed to add boot device: %v", err)
+	}
+	osParams2, err = osParams2.WithBootDevice(ovirtclient.BootDeviceNetwork)
+	if err != nil {
+		t.Fatalf("Failed to add second boot device: %v", err)
+	}
+
+	if devices := osParams2.BootDevices(); len(devices) != 2 {
+		t.Fatalf("Expected 2 boot devices, got %d", len(devices))
+	}
+
+	// Test MustWithBootDevices
+	osParams3 := ovirtclient.NewVMOSParameters().MustWithBootDevices(bootDevices)
+	if devices := osParams3.BootDevices(); len(devices) != 3 {
+		t.Fatalf("Expected 3 boot devices with Must method, got %d", len(devices))
+	}
+
+	// Test invalid boot device should fail
+	_, err = ovirtclient.NewVMOSParameters().WithBootDevice(ovirtclient.BootDevice("invalid"))
+	if err == nil {
+		t.Fatalf("Invalid boot device should have failed")
+	}
+}
+
+func TestVMCreateWithBootSequence(t *testing.T) {
+	t.Parallel()
+	helper, err := ovirtclient.NewMockTestHelper(ovirtclientlog.NewTestLogger(t))
+	if err != nil {
+		t.Fatalf("Failed to create test helper: %v", err)
+	}
+
+	cluster := helper.GetClusterID()
+	template := helper.GetBlankTemplateID()
+
+	// Create VM with boot sequence
+	osParams := ovirtclient.NewVMOSParameters().
+		MustWithType("rhel_8x64").
+		MustWithBootDevices([]ovirtclient.BootDevice{
+			ovirtclient.BootDeviceNetwork,
+			ovirtclient.BootDeviceCDROM,
+			ovirtclient.BootDeviceHD,
+		})
+
+	vmParams := ovirtclient.NewCreateVMParams().
+		WithOS(osParams)
+
+	vm, err := helper.GetClient().CreateVM(cluster, template, "test-vm-boot", vmParams)
+	if err != nil {
+		t.Fatalf("Failed to create VM: %v", err)
+	}
+	defer func() {
+		if err := helper.GetClient().RemoveVM(vm.ID()); err != nil {
+			t.Logf("Failed to remove VM: %v", err)
+		}
+	}()
+
+	// Verify boot sequence was set
+	os := vm.OS()
+	if os == nil {
+		t.Fatalf("VM OS should not be nil")
+	}
+
+	bootDevices := os.BootDevices()
+	if len(bootDevices) != 3 {
+		t.Fatalf("Expected 3 boot devices, got %d", len(bootDevices))
+	}
+
+	expectedSequence := []ovirtclient.BootDevice{
+		ovirtclient.BootDeviceNetwork,
+		ovirtclient.BootDeviceCDROM,
+		ovirtclient.BootDeviceHD,
+	}
+
+	for i, expected := range expectedSequence {
+		if bootDevices[i] != expected {
+			t.Fatalf("Boot device at position %d: expected %s, got %s", i, expected, bootDevices[i])
+		}
+	}
+}
+
+func TestVMWithEmptyBootSequence(t *testing.T) {
+	t.Parallel()
+	helper, err := ovirtclient.NewMockTestHelper(ovirtclientlog.NewTestLogger(t))
+	if err != nil {
+		t.Fatalf("Failed to create test helper: %v", err)
+	}
+
+	cluster := helper.GetClusterID()
+	template := helper.GetBlankTemplateID()
+
+	// Create VM without boot sequence
+	osParams := ovirtclient.NewVMOSParameters().MustWithType("rhel_8x64")
+
+	vmParams := ovirtclient.NewCreateVMParams().WithOS(osParams)
+
+	vm, err := helper.GetClient().CreateVM(cluster, template, "test-vm-no-boot", vmParams)
+	if err != nil {
+		t.Fatalf("Failed to create VM: %v", err)
+	}
+	defer func() {
+		if err := helper.GetClient().RemoveVM(vm.ID()); err != nil {
+			t.Logf("Failed to remove VM: %v", err)
+		}
+	}()
+
+	// Verify boot sequence is empty
+	os := vm.OS()
+	if os == nil {
+		t.Fatalf("VM OS should not be nil")
+	}
+
+	bootDevices := os.BootDevices()
+	if len(bootDevices) != 0 {
+		t.Fatalf("Expected 0 boot devices, got %d", len(bootDevices))
+	}
+}

--- a/vm_boot_test.go
+++ b/vm_boot_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestBootDevice(t *testing.T) {

--- a/vm_create.go
+++ b/vm_create.go
@@ -255,6 +255,15 @@ func vmOSCreator(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) {
 		if t := os.Type(); t != nil {
 			osBuilder.Type(*t)
 		}
+		// Add boot devices if specified
+		if bootDevices := os.BootDevices(); len(bootDevices) > 0 {
+			sdkBootDevices := make([]ovirtsdk.BootDevice, len(bootDevices))
+			for i, device := range bootDevices {
+				sdkBootDevices[i] = ovirtsdk.BootDevice(device)
+			}
+			bootBuilder := ovirtsdk.NewBootBuilder().DevicesOfAny(sdkBootDevices...)
+			osBuilder.BootBuilder(bootBuilder)
+		}
 		builder.OsBuilder(osBuilder)
 	}
 }
@@ -504,11 +513,15 @@ func (m *mockClient) createVMMemoryPolicy(params OptionalVMParameters) *memoryPo
 
 func (m *mockClient) createVMOS(params OptionalVMParameters) *vmOS {
 	os := &vmOS{
-		t: "other",
+		t:           "other",
+		bootDevices: []BootDevice{},
 	}
 	if osParams, ok := params.OS(); ok {
 		if osType := osParams.Type(); osType != nil {
 			os.t = *osType
+		}
+		if bootDevices := osParams.BootDevices(); len(bootDevices) > 0 {
+			os.bootDevices = bootDevices
 		}
 	}
 	return os

--- a/vm_create.go
+++ b/vm_create.go
@@ -30,9 +30,9 @@ func vmBuilderCPU(params OptionalVMParameters, builder *ovirtsdk.VmBuilder) {
 		if cpuTopo := cpu.Topo(); cpuTopo != nil {
 			cpuBuilder.TopologyBuilder(ovirtsdk.
 				NewCpuTopologyBuilder().
-				Cores(int64(cpu.Topo().Cores())).
-				Threads(int64(cpu.Topo().Threads())).
-				Sockets(int64(cpu.Topo().Sockets())))
+				Cores(int64(cpu.Topo().Cores())).     //nolint:gosec
+				Threads(int64(cpu.Topo().Threads())). //nolint:gosec
+				Sockets(int64(cpu.Topo().Sockets()))) //nolint:gosec
 		}
 		if mode := cpu.Mode(); mode != nil {
 			cpuBuilder.Mode(ovirtsdk.CpuMode(*mode))

--- a/vm_graphics_console_list.go
+++ b/vm_graphics_console_list.go
@@ -30,7 +30,7 @@ func (o *oVirtClient) ListVMGraphicsConsoles(vmID VMID, retries ...RetryStrategy
 	return result, err
 }
 
-func (m *mockClient) ListVMGraphicsConsoles(vmID VMID, retries ...RetryStrategy) ([]VMGraphicsConsole, error) {
+func (m *mockClient) ListVMGraphicsConsoles(vmID VMID, _ ...RetryStrategy) ([]VMGraphicsConsole, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	graphicsConsoles, ok := m.graphicsConsolesByVM[vmID]

--- a/vm_graphics_console_test.go
+++ b/vm_graphics_console_test.go
@@ -3,7 +3,7 @@ package ovirtclient_test
 import (
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestListAndRemoveGraphicsConsoles(t *testing.T) {

--- a/vm_ip_get.go
+++ b/vm_ip_get.go
@@ -145,7 +145,7 @@ func excludeInterface(
 	}
 	includedByName := isInIncludedInterfaceNames(includedInterfaceNames, interf)
 	includedByPattern := isInIncludedInterfacePatterns(includedInterfacePatterns, interf)
-	return !((len(includedInterfaceNames) == 0 && len(includedInterfacePatterns) == 0) || includedByName || includedByPattern)
+	return (len(includedInterfaceNames) != 0 || len(includedInterfacePatterns) != 0) && !includedByName && !includedByPattern
 }
 
 func isInIncludedInterfacePatterns(patterns []*regexp.Regexp, interf string) bool {

--- a/vm_ip_get_test.go
+++ b/vm_ip_get_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMIPAddressReporting(t *testing.T) {

--- a/vm_remove_test.go
+++ b/vm_remove_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMRemovalShouldRemoveAttachedDisks(t *testing.T) {

--- a/vm_search_test.go
+++ b/vm_search_test.go
@@ -3,7 +3,7 @@ package ovirtclient_test
 import (
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMSearch(t *testing.T) {

--- a/vm_tag_add.go
+++ b/vm_tag_add.go
@@ -56,7 +56,7 @@ func (o *oVirtClient) AddTagToVMByName(id VMID, tagName string, retries ...Retry
 	return
 }
 
-func (m *mockClient) AddTagToVMByName(id VMID, tagName string, retries ...RetryStrategy) (err error) {
+func (m *mockClient) AddTagToVMByName(id VMID, tagName string, _ ...RetryStrategy) (err error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/vm_tag_test.go
+++ b/vm_tag_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMTagAssignemnt(t *testing.T) {

--- a/vm_test.go
+++ b/vm_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVMListShouldNotFail(t *testing.T) {

--- a/vm_test.go
+++ b/vm_test.go
@@ -288,7 +288,7 @@ func TestVMCreationWithInit(t *testing.T) { //nolint:funlen
 			"script-test",
 			"test-vm",
 			ovirtclient.NewNicConfiguration("custom-nic", ovirtclient.IP{
-				Version: ovirtclient.IPVERSION_V4,
+				Version: ovirtclient.IPVersionV4,
 				Address: "192.168.178.15",
 				Gateway: "192.168.19.1",
 				Netmask: "255.255.255.0",
@@ -298,12 +298,12 @@ func TestVMCreationWithInit(t *testing.T) { //nolint:funlen
 			"script-test",
 			"test-vm",
 			ovirtclient.NewNicConfiguration("custom-nic", ovirtclient.IP{
-				Version: ovirtclient.IPVERSION_V4,
+				Version: ovirtclient.IPVersionV4,
 				Address: "192.168.178.15",
 				Gateway: "192.168.19.1",
 				Netmask: "255.255.255.0",
 			}).WithIPV6(ovirtclient.IP{
-				Version: ovirtclient.IPVERSION_V6,
+				Version: ovirtclient.IPVersionV6,
 				Address: "fe80::bfb6:1c6c:f541:1aa564",
 				Gateway: "fe80::",
 				Netmask: "64",
@@ -744,7 +744,7 @@ func checkVMDiskSparseness(t *testing.T, checkVM ovirtclient.VM, sparse bool, me
 		t.Fatalf("Failed to fetch disk for VM %s (%v).", checkVM.ID(), err)
 	}
 	if d.Sparse() != sparse {
-		t.Fatalf(message)
+		t.Fatal(message)
 	}
 }
 

--- a/vnicprofile_test.go
+++ b/vnicprofile_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
+	ovirtclient "github.com/dyudin0821/go-ovirt-client/v3"
 )
 
 func TestVNICProfile(t *testing.T) {


### PR DESCRIPTION
Replace all references to github.com/ovirt/go-ovirt-client/v3 with the forked module path github.com/dyudin0821/go-ovirt-client/v3 across the entire codebase.

Changes:
- Update module name in go.mod
- Replace import paths in all Go source files
- Update documentation and examples in README.md and doc.go
- Update depguard configuration in .golangci.yml